### PR TITLE
feat: export notes from home screen

### DIFF
--- a/lib/components/home/export_note_button.dart
+++ b/lib/components/home/export_note_button.dart
@@ -1,0 +1,86 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive_io.dart';
+import 'package:bson/bson.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:saber/data/editor/editor_core_info.dart';
+import 'package:saber/data/editor/editor_exporter.dart';
+import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/i18n/strings.g.dart';
+
+class ExportNoteButton extends StatefulWidget {
+  const ExportNoteButton({
+    super.key,
+    required this.cupertino,
+    required this.selectedFiles,
+  });
+
+  final bool cupertino;
+  final List<String> selectedFiles;
+
+  @override
+  State<ExportNoteButton> createState() => _ExportNoteButtonState();
+}
+
+class _ExportNoteButtonState extends State<ExportNoteButton>{
+  final ValueNotifier<bool> isDialOpen = ValueNotifier(false);
+
+  Future exportFile(List<String> selectedFiles, bool sbn2) async {
+    List<ArchiveFile> files = [];
+    for (String filePath in selectedFiles) {
+      EditorCoreInfo coreInfo = await EditorCoreInfo.loadFromFilePath(filePath);
+      if (context.mounted){
+        Uint8List content = sbn2
+        ? await (await EditorExporter.generatePdf(coreInfo, context)).save()
+        : BSON().serialize(coreInfo).byteList;
+        String fileName = sbn2
+        ? '${coreInfo.filePath.substring(coreInfo.filePath.lastIndexOf('/') + 1)}.pdf'
+        : '${coreInfo.filePath.substring(coreInfo.filePath.lastIndexOf('/') + 1)}.sbn2';
+        files.add(ArchiveFile(fileName, content.length, content));
+      }
+    }
+    if(selectedFiles.length == 1) {
+      await FileManager.exportFile(files[0].name, await files[0].content);
+    }
+    else {
+      Archive archive = Archive();
+      for (ArchiveFile pdf in files) {
+        archive.addFile(pdf);
+      }
+      await FileManager.exportFile('${files[0].name}.zip', Uint8List.fromList(ZipEncoder().encode(archive)!));
+    }
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return SpeedDial(
+      spacing: 3,
+      mini: true,
+      openCloseDial: isDialOpen,
+      childPadding: const EdgeInsets.all(5),
+      spaceBetweenChildren: 4,
+      dialRoot: (ctx, open, toggleChildren) {
+        return IconButton(
+          padding: EdgeInsets.zero,
+          tooltip: t.home.tooltips.exportNote,
+          onPressed: toggleChildren,
+          icon: const Icon(Icons.share)
+        );
+      },
+      children: [
+        SpeedDialChild(
+          child: const Icon(CupertinoIcons.doc_text),
+          label: 'PDF',
+          onTap: () => exportFile(widget.selectedFiles, true)
+        ),
+        SpeedDialChild(
+          child: const Icon(Icons.note),
+          label: 'SBN2',
+          onTap: () => exportFile(widget.selectedFiles, false)
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/home/export_note_button.dart
+++ b/lib/components/home/export_note_button.dart
@@ -5,6 +5,7 @@ import 'package:bson/bson.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:saber/components/nextcloud/spinning_loading_icon.dart';
 import 'package:saber/data/editor/editor_core_info.dart';
 import 'package:saber/data/editor/editor_exporter.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
@@ -26,8 +27,10 @@ class ExportNoteButton extends StatefulWidget {
 
 class _ExportNoteButtonState extends State<ExportNoteButton>{
   final ValueNotifier<bool> isDialOpen = ValueNotifier(false);
+  bool _currentlyExporting = false;
 
   Future exportFile(List<String> selectedFiles, bool sbn2) async {
+    setState(() {_currentlyExporting = true;}); 
     List<ArchiveFile> files = [];
     for (String filePath in selectedFiles) {
       EditorCoreInfo coreInfo = await EditorCoreInfo.loadFromFilePath(filePath);
@@ -51,8 +54,8 @@ class _ExportNoteButtonState extends State<ExportNoteButton>{
       }
       await FileManager.exportFile('${files[0].name}.zip', Uint8List.fromList(ZipEncoder().encode(archive)!));
     }
+    setState(() {_currentlyExporting = false;}); 
   }
-  
   @override
   Widget build(BuildContext context) {
     return SpeedDial(
@@ -62,12 +65,14 @@ class _ExportNoteButtonState extends State<ExportNoteButton>{
       childPadding: const EdgeInsets.all(5),
       spaceBetweenChildren: 4,
       dialRoot: (ctx, open, toggleChildren) {
-        return IconButton(
-          padding: EdgeInsets.zero,
-          tooltip: t.home.tooltips.exportNote,
-          onPressed: toggleChildren,
-          icon: const Icon(Icons.share)
-        );
+        return _currentlyExporting
+        ? const SpinningLoadingIcon()
+        : IconButton(
+            padding: EdgeInsets.zero,
+            tooltip: t.home.tooltips.exportNote,
+            onPressed: toggleChildren,
+            icon: const Icon(Icons.share)
+          );
       },
       children: [
         SpeedDialChild(

--- a/lib/components/home/export_note_button.dart
+++ b/lib/components/home/export_note_button.dart
@@ -14,11 +14,9 @@ import 'package:saber/i18n/strings.g.dart';
 class ExportNoteButton extends StatefulWidget {
   const ExportNoteButton({
     super.key,
-    required this.cupertino,
     required this.selectedFiles,
   });
 
-  final bool cupertino;
   final List<String> selectedFiles;
 
   @override

--- a/lib/components/home/export_note_button.dart
+++ b/lib/components/home/export_note_button.dart
@@ -48,7 +48,7 @@ class _ExportNoteButtonState extends State<ExportNoteButton> {
     if (selectedFiles.length == 1) {
       await FileManager.exportFile(
         files.single.name,
-        await files.single.content,
+        files.single.content,
       );
     } else {
       final archive = Archive();

--- a/lib/components/home/export_note_button.dart
+++ b/lib/components/home/export_note_button.dart
@@ -37,9 +37,11 @@ class _ExportNoteButtonState extends State<ExportNoteButton> {
       final Uint8List content = sbn2
           ? await (await EditorExporter.generatePdf(coreInfo, context)).save()
           : BSON().serialize(coreInfo).byteList;
-      final String fileName = sbn2
-          ? '${coreInfo.filePath.substring(coreInfo.filePath.lastIndexOf('/') + 1)}.pdf'
-          : '${coreInfo.filePath.substring(coreInfo.filePath.lastIndexOf('/') + 1)}.sbn2';
+      final fileNameWithoutExtension =
+          coreInfo.filePath.substring(coreInfo.filePath.lastIndexOf('/') + 1);
+      final fileName = sbn2
+          ? '$fileNameWithoutExtension.pdf'
+          : '$fileNameWithoutExtension.sbn2';
       files.add(ArchiveFile(fileName, content.length, content));
     }
 

--- a/lib/components/home/export_note_button.dart
+++ b/lib/components/home/export_note_button.dart
@@ -50,13 +50,13 @@ class _ExportNoteButtonState extends State<ExportNoteButton> {
         files.single.name,
         files.single.content,
       );
-    } else {
+    } else if (selectedFiles.length > 1) {
       final archive = Archive();
       for (final archiveFile in files) {
         archive.addFile(archiveFile);
       }
       await FileManager.exportFile(
-        '${files[0].name}.zip',
+        '${files.first.name}.zip',
         Uint8List.fromList(ZipEncoder().encode(archive)!),
       );
     }

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -340,6 +340,7 @@ class _StringsHomeTooltipsEn {
 	// Translations
 	String get newNote => 'New note';
 	String get showUpdateDialog => 'Show update dialog';
+	String get exportNote => 'Export note';
 }
 
 // Path: home.create

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -12,6 +12,7 @@ home:
   tooltips:
     newNote: New note
     showUpdateDialog: Show update dialog
+    exportNote: Export note
   create:
     newNote: New note
     importNote: Import note

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:collapsible/collapsible.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:saber/components/home/export_note_button.dart';
 import 'package:saber/components/home/grid_folders.dart';
 import 'package:saber/components/home/masonry_files.dart';
 import 'package:saber/components/home/move_note_button.dart';
@@ -238,6 +239,20 @@ class _BrowsePageState extends State<BrowsePage> {
               ]);
             },
             icon: const Icon(Icons.delete_forever),
+          ),
+        ),
+        ValueListenableBuilder(
+          valueListenable: selectedFiles,
+          builder: (context, selectedFiles, child) {
+            return Collapsible(
+              axis: CollapsibleAxis.vertical,
+              collapsed: selectedFiles.isEmpty,
+              child: child!,
+            );
+          },
+          child: ExportNoteButton(
+            cupertino: cupertino,
+            selectedFiles: selectedFiles.value,
           ),
         ),
       ],

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -251,7 +251,6 @@ class _BrowsePageState extends State<BrowsePage> {
             );
           },
           child: ExportNoteButton(
-            cupertino: cupertino,
             selectedFiles: selectedFiles.value,
           ),
         ),

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -247,12 +247,11 @@ class _BrowsePageState extends State<BrowsePage> {
             return Collapsible(
               axis: CollapsibleAxis.vertical,
               collapsed: selectedFiles.isEmpty,
-              child: child!,
+              child: ExportNoteButton(
+                selectedFiles: selectedFiles,
+              ),
             );
           },
-          child: ExportNoteButton(
-            selectedFiles: selectedFiles.value,
-          ),
         ),
       ],
     );

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:collapsible/collapsible.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:saber/components/home/export_note_button.dart';
 import 'package:saber/components/home/masonry_files.dart';
 import 'package:saber/components/home/move_note_button.dart';
 import 'package:saber/components/home/new_note_button.dart';
@@ -177,6 +178,20 @@ class _RecentPageState extends State<RecentPage> {
               ]);
             },
             icon: const Icon(Icons.delete_forever),
+          ),
+        ),
+        ValueListenableBuilder(
+          valueListenable: selectedFiles,
+          builder: (context, selectedFiles, child) {
+            return Collapsible(
+              axis: CollapsibleAxis.vertical,
+              collapsed: selectedFiles.isEmpty,
+              child: child!,
+            );
+          },
+          child: ExportNoteButton(
+            cupertino: cupertino,
+            selectedFiles: selectedFiles.value,
           ),
         ),
       ],

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -190,7 +190,6 @@ class _RecentPageState extends State<RecentPage> {
             );
           },
           child: ExportNoteButton(
-            cupertino: cupertino,
             selectedFiles: selectedFiles.value,
           ),
         ),

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -186,12 +186,11 @@ class _RecentPageState extends State<RecentPage> {
             return Collapsible(
               axis: CollapsibleAxis.vertical,
               collapsed: selectedFiles.isEmpty,
-              child: child!,
+              child: ExportNoteButton(
+                selectedFiles: selectedFiles,
+              ),
             );
           },
-          child: ExportNoteButton(
-            selectedFiles: selectedFiles.value,
-          ),
         ),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -18,7 +18,7 @@ packages:
     source: hosted
     version: "2.0.4"
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       sha256: "0da817eab9833cc222ee5575789664e99f60fe0c554be55dc1979f9b4ec6dd73"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,6 +103,8 @@ dependencies:
 
   worker_manager: ^6.0.0
 
+  archive: ^3.4.6
+
   # Using a fork because the original uses an old version of kotlin and doesn't support text files
   receive_sharing_intent:
     git:


### PR DESCRIPTION
This adds a button export/share all selected notes in the "Browse" and "Recent Notes" tabs on the home screen, like suggested in #922 . When you press the button a menu like the one for creating notes opens where you can choose whether to export it as SBN2 or PDF. When multiple notes are selected, a zip file with all of the exported notes gets created.