### PR TITLE
fix: import sbn/sbn2 when in root folder

### DIFF
--- a/lib/components/home/move_note_button.dart
+++ b/lib/components/home/move_note_button.dart
@@ -126,7 +126,7 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
   @override
   void initState() {
     currentFolder = _findMostCommonParentFolder();
-    if(!currentFolder.startsWith('/')) {
+    if (!currentFolder.startsWith('/')) {
       currentFolder = '/$currentFolder';
     }
     super.initState();

--- a/lib/components/home/move_note_button.dart
+++ b/lib/components/home/move_note_button.dart
@@ -126,6 +126,9 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
   @override
   void initState() {
     currentFolder = _findMostCommonParentFolder();
+    if(!currentFolder.startsWith('/')) {
+      currentFolder = '/$currentFolder';
+    }
     super.initState();
 
     findOldExtensions()

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -84,7 +84,7 @@ class _NewNoteButtonState extends State<NewNoteButton>{
               
               final fileNameWithoutExtension = fileName.substring(0, fileName.length - '.pdf'.length);
               final sbnFilePath = await FileManager.suffixFilePathToMakeItUnique(
-                '${widget.path}/$fileNameWithoutExtension',
+                widget.path == null ? '/$fileNameWithoutExtension' : '${widget.path}/$fileNameWithoutExtension',
                 false,
               );
               if (!mounted) return;

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -72,7 +72,7 @@ class _NewNoteButtonState extends State<NewNoteButton>{
             if (filePath.endsWith('.sbn') || filePath.endsWith('.sbn2')) {
               final path = await FileManager.importFile(
                 filePath,
-                widget.path == null ? null : '${widget.path}/',
+                '${widget.path ?? ''}/',
                 filePath.endsWith('.sbn'),
               );
               if (path == null) return;

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -72,12 +72,12 @@ class _NewNoteButtonState extends State<NewNoteButton>{
             if (filePath.endsWith('.sbn') || filePath.endsWith('.sbn2')) {
               final path = await FileManager.importFile(
                 filePath,
-                '${widget.path}/',
+                widget.path == null ? null : '${widget.path}/',
                 filePath.endsWith('.sbn'),
               );
               if (path == null) return;
               if (!mounted) return;
-              context.push(RoutePaths.editFilePath(path));
+              context.push(RoutePaths.editFilePath(path.substring(0, path.length - (filePath.endsWith('.sbn') ? '.sbn'.length : '.sbn2'.length))));
             } else if (filePath.endsWith('.pdf')) {
               if (!Editor.canRasterPdf) return;
               if (!mounted) return;

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -77,14 +77,16 @@ class _NewNoteButtonState extends State<NewNoteButton>{
               );
               if (path == null) return;
               if (!mounted) return;
-              context.push(RoutePaths.editFilePath(path.substring(0, path.length - (filePath.endsWith('.sbn') ? '.sbn'.length : '.sbn2'.length))));
+
+              final filePathWithoutExtension = path.substring(0, path.lastIndexOf('.'));
+              context.push(RoutePaths.editFilePath(filePathWithoutExtension));
             } else if (filePath.endsWith('.pdf')) {
               if (!Editor.canRasterPdf) return;
               if (!mounted) return;
-              
+            
               final fileNameWithoutExtension = fileName.substring(0, fileName.length - '.pdf'.length);
               final sbnFilePath = await FileManager.suffixFilePathToMakeItUnique(
-                widget.path == null ? '/$fileNameWithoutExtension' : '${widget.path}/$fileNameWithoutExtension',
+                '${widget.path ?? ''}/$fileNameWithoutExtension',
                 false,
               );
               if (!mounted) return;

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -11,6 +11,7 @@ import 'package:saber/components/home/rename_note_button.dart';
 import 'package:saber/components/home/syncing_button.dart';
 import 'package:saber/components/home/welcome.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/data/prefs.dart';
 import 'package:saber/data/routes.dart';
 import 'package:saber/i18n/strings.g.dart';
 import 'package:saber/pages/editor/editor.dart';
@@ -28,12 +29,26 @@ class _RecentPageState extends State<RecentPage> {
 
   final ValueNotifier<List<String>> selectedFiles = ValueNotifier([]);
 
+  //Move files that got imported (and moved) with a missing '/' in the path
+  void moveIncorrectlyImportedFiles() async {
+    for(String file in Prefs.recentFiles.value) {
+      if(!file.startsWith('/')) {
+        String newFilePath = await FileManager.suffixFilePathToMakeItUnique('/$file', false);
+        await FileManager.moveFile(
+          file,
+          newFilePath,
+        );
+      }
+    }
+  }
+
   @override
   void initState() {
     findRecentlyAccessedNotes();
     fileWriteSubscription = FileManager.fileWriteStream.stream.listen(fileWriteListener);
 
     super.initState();
+    moveIncorrectlyImportedFiles();
   }
 
   StreamSubscription? fileWriteSubscription;

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -33,7 +33,12 @@ class _RecentPageState extends State<RecentPage> {
   void moveIncorrectlyImportedFiles() async {
     for(String file in Prefs.recentFiles.value) {
       if(!file.startsWith('/')) {
-        String newFilePath = await FileManager.suffixFilePathToMakeItUnique('/$file', false);
+        String newFilePath;
+        if(file.startsWith('null')) {
+          newFilePath = await FileManager.suffixFilePathToMakeItUnique(file.substring('null'.length), false);
+        } else {
+          newFilePath = await FileManager.suffixFilePathToMakeItUnique('/$file', false);
+        }
         await FileManager.moveFile(
           file,
           newFilePath,


### PR DESCRIPTION
This fixes the import of .sbn and .sbn2 files into the root directory. When widget.path was null, importFile() was called with the parameter 'null/' which caused the file not to be imported. Also, this makes the imported note open correctly after importing by removing the file extension from the path (previously, an empty .sbn2.sbn2 file was opened).