### PR TITLE
feat: setting to show/hide shape pen preview

### DIFF
--- a/lib/data/prefs.dart
+++ b/lib/data/prefs.dart
@@ -83,6 +83,8 @@ abstract class Prefs {
   static late final PlainPref<bool> disableEraserAfterUse;
   static late final PlainPref<bool> hideFingerDrawingToggle;
 
+  static late final PlainPref<bool> showShapePreview;
+
   static late final PlainPref<List<String>> recentColorsChronological;
   static late final PlainPref<List<String>> recentColorsPositioned;
   static late final PlainPref<List<String>> pinnedColors;
@@ -164,6 +166,8 @@ abstract class Prefs {
 
     disableEraserAfterUse = PlainPref('disableEraserAfterUse', false);
     hideFingerDrawingToggle = PlainPref('hideFingerDrawingToggle', false);
+
+    showShapePreview = PlainPref('showShapePreview', true);
 
     recentColorsChronological = PlainPref('recentColorsChronological', []);
     recentColorsPositioned = PlainPref('recentColorsPositioned', [], historicalKeys: const ['recentColors']);

--- a/lib/data/tools/shape_pen.dart
+++ b/lib/data/tools/shape_pen.dart
@@ -41,7 +41,7 @@ class ShapePen extends Pen {
   void onDragUpdate(Offset position, double? pressure) {
     super.onDragUpdate(position, pressure);
 
-    if (_detectShapeDebouncer == null || !_detectShapeDebouncer!.isActive) {
+    if (Prefs.showShapePreview.value && (_detectShapeDebouncer == null || !_detectShapeDebouncer!.isActive)) {
       _detectShapeDebouncer = Timer(_debounceDuration, _detectShape);
     }
   }

--- a/lib/i18n/_missing_translations.yaml
+++ b/lib/i18n/_missing_translations.yaml
@@ -41,6 +41,7 @@ ar:
       allowInsecureConnections(OUTDATED): Allow insecure connections
       disableEraserAfterUse(OUTDATED): Auto-disable the eraser
       hideFingerDrawingToggle(OUTDATED): Hide the finger drawing toggle
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
       autosaveDelay(OUTDATED): Auto-save delay
     prefDescriptions:
@@ -51,6 +52,7 @@ ar:
         shown(OUTDATED): Prevents accidental toggling
         fixedOn(OUTDATED): Finger drawing is fixed as enabled
         fixedOff(OUTDATED): Finger drawing is fixed as disabled
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
       autosaveDelay(OUTDATED): How long to wait before auto-saving a note
       shouldAlwaysAlertForUpdates(OUTDATED): Tell me about updates as soon as they're available
   editor:
@@ -71,6 +73,11 @@ ar:
       bgPatterns:
         tablature(OUTDATED): Tablature
 cs:
+  settings:
+    prefLabels:
+      showShapePreview: Shape pen preview
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
 de:
   home:
     titles:
@@ -107,6 +114,7 @@ de:
       shouldAlwaysAlertForUpdates(OUTDATED): Faster updates
       disableEraserAfterUse(OUTDATED): Auto-disable the eraser
       hideFingerDrawingToggle(OUTDATED): Hide the finger drawing toggle
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
       autosaveDelay(OUTDATED): Auto-save delay
     prefDescriptions:
@@ -115,6 +123,7 @@ de:
         shown(OUTDATED): Prevents accidental toggling
         fixedOn(OUTDATED): Finger drawing is fixed as enabled
         fixedOff(OUTDATED): Finger drawing is fixed as disabled
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
       autosaveDelay(OUTDATED): How long to wait before auto-saving a note
       shouldAlwaysAlertForUpdates(OUTDATED): Tell me about updates as soon as they're available
   editor:
@@ -144,7 +153,10 @@ es:
       numberRenamedTo(OUTDATED): $n notes will be renamed to avoid conflicts
   settings:
     prefLabels:
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
@@ -176,7 +188,10 @@ fa:
       folderNameExists(OUTDATED): A folder with this name already exists
   settings:
     prefLabels:
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
@@ -204,7 +219,10 @@ fr:
       numberRenamedTo(OUTDATED): $n notes will be renamed to avoid conflicts
   settings:
     prefLabels:
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
@@ -232,7 +250,10 @@ he:
       numberRenamedTo(OUTDATED): $n notes will be renamed to avoid conflicts
   settings:
     prefLabels:
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
@@ -307,6 +328,7 @@ hu:
       allowInsecureConnections(OUTDATED): Allow insecure connections
       disableEraserAfterUse(OUTDATED): Auto-disable the eraser
       hideFingerDrawingToggle(OUTDATED): Hide the finger drawing toggle
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
       printPageIndicators(OUTDATED): Print page indicators
       autosaveDelay(OUTDATED): Auto-save delay
@@ -318,6 +340,7 @@ hu:
         shown(OUTDATED): Prevents accidental toggling
         fixedOn(OUTDATED): Finger drawing is fixed as enabled
         fixedOff(OUTDATED): Finger drawing is fixed as disabled
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
       printPageIndicators(OUTDATED): Show page indicators in exports
       autosaveDelay(OUTDATED): How long to wait before auto-saving a note
       shouldAlwaysAlertForUpdates(OUTDATED): Tell me about updates as soon as they're available
@@ -422,6 +445,11 @@ hu:
       lockAxisAlignedPan(OUTDATED): Lock panning to horizontal or vertical
     needsToSaveBeforeExiting(OUTDATED): Saving your changes... You can safely exit the editor when it's done
 it:
+  settings:
+    prefLabels:
+      showShapePreview: Shape pen preview
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
 ja:
   home:
     titles:
@@ -455,6 +483,7 @@ ja:
       shouldAlwaysAlertForUpdates(OUTDATED): Faster updates
       disableEraserAfterUse(OUTDATED): Auto-disable the eraser
       hideFingerDrawingToggle(OUTDATED): Hide the finger drawing toggle
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
       autosaveDelay(OUTDATED): Auto-save delay
     prefDescriptions:
@@ -463,6 +492,7 @@ ja:
         shown(OUTDATED): Prevents accidental toggling
         fixedOn(OUTDATED): Finger drawing is fixed as enabled
         fixedOff(OUTDATED): Finger drawing is fixed as disabled
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
       autosaveDelay(OUTDATED): How long to wait before auto-saving a note
       shouldAlwaysAlertForUpdates(OUTDATED): Tell me about updates as soon as they're available
   editor:
@@ -492,7 +522,10 @@ pt-BR:
       numberRenamedTo(OUTDATED): $n notes will be renamed to avoid conflicts
   settings:
     prefLabels:
+      showShapePreview: Shape pen preview
       recentColorsLength(OUTDATED): How many recent colors to store
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
@@ -510,6 +543,11 @@ ru:
   home:
     tooltips:
       exportNote(OUTDATED): Export note
+  settings:
+    prefLabels:
+      showShapePreview: Shape pen preview
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
@@ -517,6 +555,11 @@ tr:
   home:
     tooltips:
       exportNote(OUTDATED): Export note
+  settings:
+    prefLabels:
+      showShapePreview: Shape pen preview
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
@@ -524,7 +567,17 @@ zh-Hans-CN:
   home:
     tooltips:
       exportNote(OUTDATED): Export note
+  settings:
+    prefLabels:
+      showShapePreview: Shape pen preview
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
   editor:
     pens:
       pencil(OUTDATED): Pencil
 zh-Hant-TW:
+  settings:
+    prefLabels:
+      showShapePreview: Shape pen preview
+    prefDescriptions:
+      showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 16
-/// Strings: 3998 (249 per locale)
+/// Strings: 4000 (250 per locale)
 ///
-/// Built on 2023-11-26 at 18:43 UTC
+/// Built on 2023-12-02 at 15:15 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -468,6 +468,7 @@ class _StringsSettingsPrefLabelsEn {
 	String get autoClearWhiteboardOnExit => 'Auto-clear the whiteboard';
 	String get disableEraserAfterUse => 'Auto-disable the eraser';
 	String get hideFingerDrawingToggle => 'Hide the finger drawing toggle';
+	String get showShapePreview => 'Shape pen preview';
 	String get editorPromptRename => 'Prompt you to rename new notes';
 	String get hideHomeBackgrounds => 'Hide backgrounds on the home screen';
 	String get recentColorsDontSavePresets => 'Don\'t save preset colors in recent colors';
@@ -492,6 +493,7 @@ class _StringsSettingsPrefDescriptionsEn {
 	String get disableEraserAfterUse => 'Automatically switches back to the pen after using the eraser';
 	String get maxImageSize => 'Larger images will be compressed';
 	late final _StringsSettingsPrefDescriptionsHideFingerDrawingEn hideFingerDrawing = _StringsSettingsPrefDescriptionsHideFingerDrawingEn._(_root);
+	String get showShapePreview => 'Show a preview of the shape when using the shape pen (disabling this may reduce lag)';
 	String get editorPromptRename => 'You can always rename notes later';
 	String get hideHomeBackgrounds => 'For a cleaner look';
 	String get printPageIndicators => 'Show page indicators in exports';

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -83,6 +83,7 @@ settings:
     autoClearWhiteboardOnExit: Auto-clear the whiteboard
     disableEraserAfterUse: Auto-disable the eraser
     hideFingerDrawingToggle: Hide the finger drawing toggle
+    showShapePreview: Shape pen preview
     editorPromptRename: Prompt you to rename new notes
     hideHomeBackgrounds: Hide backgrounds on the home screen
     recentColorsDontSavePresets: Don't save preset colors in recent colors
@@ -102,6 +103,7 @@ settings:
       shown: Prevents accidental toggling
       fixedOn: Finger drawing is fixed as enabled
       fixedOff: Finger drawing is fixed as disabled
+    showShapePreview: Show a preview of the shape when using the shape pen (disabling this may reduce lag)
     editorPromptRename: You can always rename notes later
     hideHomeBackgrounds: For a cleaner look
     printPageIndicators: Show page indicators in exports

--- a/lib/pages/home/settings.dart
+++ b/lib/pages/home/settings.dart
@@ -328,6 +328,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 pref: Prefs.hideFingerDrawingToggle,
                 afterChange: (_) => setState(() {}),
               ),
+              SettingsSwitch(
+                title: t.settings.prefLabels.showShapePreview,
+                subtitle: t.settings.prefDescriptions.showShapePreview,
+                icon: FontAwesomeIcons.shapes,
+                pref: Prefs.showShapePreview,
+              ),
               
               SettingsSubtitle(subtitle: t.settings.prefCategories.editor),
               SettingsSelection(


### PR DESCRIPTION
The lag of the shape pen described in #1019 is mostly caused by rendering the shape preview 10 times per second. This adds a setting to hide the preview, which greatly reduces the lag.