### PR TITLE
perf: use thumbnails on the home screen

### DIFF
--- a/lib/components/canvas/canvas_preview.dart
+++ b/lib/components/canvas/canvas_preview.dart
@@ -4,6 +4,8 @@ import 'package:saber/data/editor/editor_core_info.dart';
 import 'package:saber/data/editor/page.dart';
 import 'package:saber/data/prefs.dart';
 
+typedef _CacheItem = (EditorCoreInfo coreInfo, double pageHeight);
+
 class CanvasPreview extends StatelessWidget {
   const CanvasPreview({
     super.key,
@@ -15,6 +17,41 @@ class CanvasPreview extends StatelessWidget {
   final int pageIndex;
   final double? height;
   final EditorCoreInfo coreInfo;
+
+  static final _previewCache = <String, Future<_CacheItem>>{};
+  static Widget fromFile({
+    Key? key,
+    required String filePath,
+  }) {
+    final Future<_CacheItem> future;
+    if (_previewCache.containsKey(filePath)) {
+      future = _previewCache[filePath]!;
+    } else {
+      _previewCache[filePath] = future = () async {
+        final coreInfo = await EditorCoreInfo.loadFromFilePath(filePath);
+        final pageHeight = coreInfo.pages.isNotEmpty
+            ? coreInfo.pages[0].previewHeight(lineHeight: coreInfo.lineHeight)
+            : EditorPage.defaultHeight * 0.1;
+        return (coreInfo, pageHeight);
+      }();
+    }
+
+    return FutureBuilder(
+      key: key,
+      future: future,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+        if (data == null) {
+          return const CircularProgressIndicator.adaptive();
+        }
+        return CanvasPreview(
+          key: key,
+          coreInfo: data.$1,
+          height: data.$2,
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/components/canvas/image/pdf_editor_image.dart
+++ b/lib/components/canvas/image/pdf_editor_image.dart
@@ -199,7 +199,7 @@ class PdfEditorImage extends EditorImage {
       valueListenable: anyDpiRaster,
       builder: (context, imageProvider, child) {
         if (imageProvider == null) {
-          return const Center(child: CircularProgressIndicator());
+          return const Center(child: CircularProgressIndicator.adaptive());
         }
         return Image(
           image: imageProvider,

--- a/lib/components/canvas/image/svg_editor_image.dart
+++ b/lib/components/canvas/image/svg_editor_image.dart
@@ -180,7 +180,7 @@ class SvgEditorImage extends EditorImage {
     required bool isBackground,
   }) {
     if (svgString == null) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: CircularProgressIndicator.adaptive());
     }
 
     final BoxFit boxFit;

--- a/lib/components/canvas/save_indicator.dart
+++ b/lib/components/canvas/save_indicator.dart
@@ -27,7 +27,7 @@ class SaveIndicator extends StatelessWidget {
             onPressed: () => _onPressed(context),
             icon: switch (savingState.value) {
               SavingState.waitingToSave => const Icon(Icons.save),
-              SavingState.saving => const CircularProgressIndicator(),
+              SavingState.saving => const CircularProgressIndicator.adaptive(),
               SavingState.saved => const Icon(Icons.arrow_back),
             },
           ),

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -1,18 +1,12 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:saber/components/canvas/_stroke.dart';
-import 'package:saber/components/canvas/canvas_preview.dart';
-import 'package:saber/components/canvas/image/editor_image.dart';
-import 'package:saber/components/canvas/inner_canvas.dart';
+import 'package:saber/components/canvas/invert_shader.dart';
+import 'package:saber/components/canvas/shader_sampler.dart';
 import 'package:saber/components/home/uploading_indicator.dart';
 import 'package:saber/components/navbar/responsive_navbar.dart';
-import 'package:saber/data/editor/editor_core_info.dart';
-import 'package:saber/data/editor/page.dart';
-import 'package:saber/data/extensions/color_extensions.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/prefs.dart';
 import 'package:saber/data/routes.dart';
@@ -33,117 +27,16 @@ class PreviewCard extends StatefulWidget {
 
   @override
   State<PreviewCard> createState() => _PreviewCardState();
-
-  static EditorCoreInfo getCachedCoreInfo(String filePath) =>
-      _PreviewCardState.getCachedCoreInfo(filePath);
-  static void moveFileInCache(String oldPath, String newPath) =>
-      _PreviewCardState.moveFileInCache(oldPath, newPath);
 }
 
 class _PreviewCardState extends State<PreviewCard> {
-  /// cache strokes so there's no delay the second time we see this preview card
-  static final Map<String, EditorCoreInfo> _mapFilePathToEditorInfo = {};
-  static EditorCoreInfo getCachedCoreInfo(String filePath) {
-    return _mapFilePathToEditorInfo[filePath] ??
-        EditorCoreInfo(filePath: filePath);
-  }
-
-  static void moveFileInCache(String oldPath, String newPath) {
-    if (oldPath.endsWith(Editor.extension)) {
-      oldPath = oldPath.substring(0, oldPath.length - Editor.extension.length);
-    } else if (oldPath.endsWith(Editor.extensionOldJson)) {
-      oldPath =
-          oldPath.substring(0, oldPath.length - Editor.extensionOldJson.length);
-    } else {
-      assert(false,
-          'oldPath must end with ${Editor.extension} or ${Editor.extensionOldJson}');
-    }
-
-    if (newPath.endsWith(Editor.extension)) {
-      newPath = newPath.substring(0, newPath.length - Editor.extension.length);
-    } else if (newPath.endsWith(Editor.extensionOldJson)) {
-      newPath =
-          newPath.substring(0, newPath.length - Editor.extensionOldJson.length);
-    } else {
-      assert(false,
-          'newPath must end with ${Editor.extension} or ${Editor.extensionOldJson}');
-    }
-
-    if (!_mapFilePathToEditorInfo.containsKey(oldPath)) return;
-    _mapFilePathToEditorInfo[newPath] = _mapFilePathToEditorInfo[oldPath]!;
-    _mapFilePathToEditorInfo.remove(oldPath);
-  }
-
-  ValueNotifier<bool> expanded = ValueNotifier(false);
-
-  late double heightWidthRatio = _getHeightWidthRatio();
-  late EditorCoreInfo _coreInfo = getCachedCoreInfo(widget.filePath);
-  EditorCoreInfo get coreInfo => _coreInfo;
-  set coreInfo(EditorCoreInfo coreInfo) {
-    _mapFilePathToEditorInfo[widget.filePath] = _coreInfo = coreInfo;
-    heightWidthRatio = _getHeightWidthRatio();
-  }
-
-  /// The cropped height of the first page
-  /// as a percentage of the width of the canvas
-  /// (cropped to its content for a masonry layout).
-  ///
-  /// The cropped height (not ratio) will be between 10% and 100% of the
-  /// maximum height of the first page,
-  /// or 0 if an error occurs.
-  double _getHeightWidthRatio() {
-    final EditorPage firstPage;
-    if (coreInfo.pages.isEmpty) {
-      firstPage = EditorPage();
-    } else {
-      firstPage = coreInfo.pages.first;
-    }
-
-    // avoid dividing by zero (this should never happen)
-    assert(firstPage.size.height != 0);
-    assert(firstPage.size.width != 0);
-    if (firstPage.size.height == 0 || firstPage.size.width == 0) {
-      return 0;
-    }
-
-    // if we have a background image, show full height
-    if (firstPage.backgroundImage != null) {
-      return firstPage.size.height / firstPage.size.width;
-    }
-
-    /// The maximum y value of any stroke, image, or text.
-    double maxY = 0;
-    for (Stroke stroke in firstPage.strokes) {
-      maxY = max(maxY, stroke.maxY);
-    }
-    for (EditorImage image in firstPage.images) {
-      maxY = max(maxY, image.dstRect.bottom);
-    }
-    if (!firstPage.quill.controller.document.isEmpty()) {
-      // this does not account for text that wraps to the next line
-      int linesOfText =
-          firstPage.quill.controller.document.toPlainText().split('\n').length;
-      maxY = max(
-          maxY, linesOfText * coreInfo.lineHeight * 1.5); // ×1.5 fudge factor
-    }
-
-    /// The height of the first page (uncropped).
-    /// e.g. the default height is 1400 [EditorPage.defaultHeight]
-    /// and the default width is 1000 [EditorPage.defaultWidth].
-    double fullHeight = firstPage.size.height;
-
-    /// The height of the canvas (cropped),
-    /// adjusted to be between 10% and 100% of the full height.
-    final canvasHeight = min(fullHeight, max(maxY, 0) + (0.1 * fullHeight));
-
-    return canvasHeight / firstPage.size.width;
-  }
+  final expanded = ValueNotifier(false);
+  final thumbnailState = _ThumbnailState();
+  late FileImage thumbnailImage;
+  late final shader = InvertShader.create();
 
   @override
   void initState() {
-    if (_coreInfo.isEmpty) {
-      findStrokes();
-    }
     fileWriteSubscription =
         FileManager.fileWriteStream.stream.listen(fileWriteListener);
 
@@ -151,44 +44,25 @@ class _PreviewCardState extends State<PreviewCard> {
     super.initState();
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    thumbnailImage = FileImage(
+      FileManager.getFile('${widget.filePath}${Editor.extension}.png'),
+    );
+  }
+
   StreamSubscription? fileWriteSubscription;
   void fileWriteListener(FileOperation event) {
     if (event.filePath != widget.filePath) return;
     if (event.type == FileOperationType.delete) {
-      setState(() {
-        coreInfo = EditorCoreInfo(filePath: widget.filePath);
-      });
+      thumbnailState.hide = true;
     } else if (event.type == FileOperationType.write) {
-      findStrokes(fromFileListener: true);
+      thumbnailImage.evict();
+      thumbnailState.markAsChanged();
     } else {
       throw Exception('Unknown file operation type: ${event.type}');
     }
-  }
-
-  Future findStrokes({bool fromFileListener = false}) async {
-    if (!mounted) return;
-
-    if (fromFileListener) {
-      // don't refresh if we're not on the home page
-      final location = GoRouterState.of(context).uri.toString();
-      if (!location.startsWith(RoutePaths.prefixOfHome)) return;
-    }
-
-    coreInfo = await EditorCoreInfo.loadFromFilePath(
-      widget.filePath,
-      readOnly: true,
-      onlyFirstPage: true, // only keep first page
-    )
-      ..readOnlyBecauseOfVersion = false;
-    assert(coreInfo.pages.length <= 1);
-
-    for (final page in coreInfo.pages) {
-      for (final stroke in page.strokes) {
-        stroke.optimisePoints(thresholdMultiplier: 2);
-      }
-    }
-
-    if (mounted) setState(() {});
   }
 
   void _toggleCardSelection() {
@@ -203,13 +77,8 @@ class _PreviewCardState extends State<PreviewCard> {
     final disableAnimations = MediaQuery.of(context).disableAnimations;
     final transitionDuration =
         Duration(milliseconds: disableAnimations ? 0 : 300);
-    final background =
-        coreInfo.backgroundColor ?? InnerCanvas.defaultBackgroundColor;
     final invert =
         theme.brightness == Brightness.dark && Prefs.editorAutoInvert.value;
-    final firstPageWidth = coreInfo.pages.isEmpty
-        ? EditorPage.defaultWidth
-        : coreInfo.pages.first.size.width;
 
     Widget card = MouseRegion(
       cursor: SystemMouseCursors.click,
@@ -226,22 +95,27 @@ class _PreviewCardState extends State<PreviewCard> {
                 children: [
                   Stack(
                     children: [
-                      FittedBox(
-                        child: AnimatedContainer(
-                          duration: transitionDuration,
-                          width: firstPageWidth,
-                          height: heightWidthRatio * firstPageWidth,
-                          color: background.withInversion(invert),
-                          child: ClipRect(
-                            child: AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 300),
-                              child: CanvasPreview(
-                                key: ValueKey(coreInfo),
-                                height: heightWidthRatio * firstPageWidth,
-                                coreInfo: coreInfo,
-                              ),
-                            ),
-                          ),
+                      AnimatedBuilder(
+                        animation: thumbnailState,
+                        builder: (context, _) => AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 300),
+                          child: thumbnailState.hide
+                              ? const SizedBox.shrink()
+                              : ShaderSampler(
+                                  shaderEnabled: invert,
+                                  prepareForSnapshot: () =>
+                                      precacheImage(thumbnailImage, context),
+                                  shaderBuilder: (image, size) {
+                                    shader.setFloat(0, size.width);
+                                    shader.setFloat(1, size.height);
+                                    shader.setImageSampler(0, image);
+                                    return shader;
+                                  },
+                                  child: Image(
+                                    key: ValueKey(thumbnailState.updateCount),
+                                    image: thumbnailImage,
+                                  ),
+                                ),
                         ),
                       ),
                       Positioned.fill(
@@ -300,38 +174,61 @@ class _PreviewCardState extends State<PreviewCard> {
     );
 
     return ValueListenableBuilder(
-        valueListenable: expanded,
-        builder: (context, expanded, _) {
-          return OpenContainer(
-            closedColor: colorScheme.surface,
-            closedShape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-            closedElevation: expanded ? 4 : 1,
-            closedBuilder: (context, action) => card,
-            openColor: colorScheme.background,
-            openBuilder: (context, action) => Editor(path: widget.filePath),
-            transitionDuration: transitionDuration,
-            routeSettings: RouteSettings(
-              name: RoutePaths.editFilePath(widget.filePath),
-            ),
-            onClosed: (_) async {
-              findStrokes();
+      valueListenable: expanded,
+      builder: (context, expanded, _) {
+        return OpenContainer(
+          closedColor: colorScheme.surface,
+          closedShape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          closedElevation: expanded ? 4 : 1,
+          closedBuilder: (context, action) => card,
+          openColor: colorScheme.background,
+          openBuilder: (context, action) => Editor(path: widget.filePath),
+          transitionDuration: transitionDuration,
+          routeSettings: RouteSettings(
+            name: RoutePaths.editFilePath(widget.filePath),
+          ),
+          onClosed: (_) async {
+            thumbnailImage.evict();
+            thumbnailState.markAsChanged();
 
-              await Future.delayed(transitionDuration);
-              if (!mounted) return;
-              if (!GoRouterState.of(context)
-                  .uri
-                  .toString()
-                  .startsWith(RoutePaths.prefixOfHome)) return;
-              ResponsiveNavbar.setAndroidNavBarColor(theme);
-            },
-          );
-        });
+            await Future.delayed(transitionDuration);
+            if (!mounted) return;
+            if (!GoRouterState.of(context)
+                .uri
+                .toString()
+                .startsWith(RoutePaths.prefixOfHome)) return;
+            ResponsiveNavbar.setAndroidNavBarColor(theme);
+          },
+        );
+      },
+    );
   }
 
   @override
   void dispose() {
     fileWriteSubscription?.cancel();
     super.dispose();
+  }
+}
+
+class _ThumbnailState extends ChangeNotifier {
+  int updateCount = 0;
+
+  bool _hide = false;
+
+  /// Whether to hide the thumbnail,
+  /// i.e. if the note has been deleted.
+  bool get hide => _hide;
+  set hide(bool value) {
+    if (_hide == value) return;
+    _hide = value;
+    ++updateCount;
+    notifyListeners();
+  }
+
+  void markAsChanged() {
+    ++updateCount;
+    notifyListeners();
   }
 }

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -48,7 +48,7 @@ class _PreviewCardState extends State<PreviewCard> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     thumbnailImage = FileImage(
-      FileManager.getFile('${widget.filePath}${Editor.extension}.png'),
+      FileManager.getFile('${widget.filePath}${Editor.extension}.p'),
     );
   }
 

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:saber/components/canvas/canvas_preview.dart';
 import 'package:saber/components/canvas/invert_shader.dart';
 import 'package:saber/components/canvas/shader_sampler.dart';
 import 'package:saber/components/home/uploading_indicator.dart';
@@ -114,6 +116,23 @@ class _PreviewCardState extends State<PreviewCard> {
                                   child: Image(
                                     key: ValueKey(thumbnailState.updateCount),
                                     image: thumbnailImage,
+                                    errorBuilder: (context, error, stackTrace) {
+                                      // If the thumbnail image doesn't exist,
+                                      // (i.e. for old notes), render the first page.
+                                      if (error is! PathNotFoundException) {
+                                        throw error;
+                                      }
+
+                                      return FittedBox(
+                                        child: ClipRect(
+                                          child: CanvasPreview.fromFile(
+                                            key: ValueKey(
+                                                'CanvasPreview${thumbnailState.updateCount}'),
+                                            filePath: widget.filePath,
+                                          ),
+                                        ),
+                                      );
+                                    },
                                   ),
                                 ),
                         ),

--- a/lib/components/home/syncing_button.dart
+++ b/lib/components/home/syncing_button.dart
@@ -107,7 +107,7 @@ class _AnimatedCircularProgressIndicatorState
     if (percentage == 0 && widget.percentage == null) {
       percentage = null;
     }
-    return CircularProgressIndicator(
+    return CircularProgressIndicator.adaptive(
       semanticsLabel: 'Syncing progress',
       semanticsValue: '${(percentage ?? 0) * 100}%',
       value: percentage,

--- a/lib/components/home/syncing_button.dart
+++ b/lib/components/home/syncing_button.dart
@@ -107,7 +107,7 @@ class _AnimatedCircularProgressIndicatorState
     if (percentage == 0 && widget.percentage == null) {
       percentage = null;
     }
-    return CircularProgressIndicator.adaptive(
+    return CircularProgressIndicator(
       semanticsLabel: 'Syncing progress',
       semanticsValue: '${(percentage ?? 0) * 100}%',
       value: percentage,

--- a/lib/components/settings/nextcloud_profile.dart
+++ b/lib/components/settings/nextcloud_profile.dart
@@ -92,7 +92,7 @@ class _NextcloudProfileState extends State<NextcloudProfile> {
                     return Stack(
                       alignment: Alignment.center,
                       children: [
-                        CircularProgressIndicator.adaptive(
+                        CircularProgressIndicator(
                           value: relativePercent,
                           backgroundColor: colorScheme.primary.withOpacity(0.1),
                           valueColor: AlwaysStoppedAnimation<Color>(

--- a/lib/components/settings/nextcloud_profile.dart
+++ b/lib/components/settings/nextcloud_profile.dart
@@ -92,10 +92,12 @@ class _NextcloudProfileState extends State<NextcloudProfile> {
                     return Stack(
                       alignment: Alignment.center,
                       children: [
-                        CircularProgressIndicator(
+                        CircularProgressIndicator.adaptive(
                           value: relativePercent,
-                          color: colorScheme.primary.withOpacity(0.5),
                           backgroundColor: colorScheme.primary.withOpacity(0.1),
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            colorScheme.primary.withOpacity(0.5),
+                          ),
                           strokeWidth: 8,
                           semanticsLabel: 'Storage usage',
                           semanticsValue: snapshot.data != null

--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -37,8 +37,8 @@ class FileManager {
   static String _sanitisePath(String path) => File(path).path;
 
   /// A regex that matches the file names/paths of asset files,
-  /// e.g. `mynote.sbn2.1`.
-  static final assetFileRegex = RegExp(r'\.sbn2?\.\d+$');
+  /// including previews, e.g. `mynote.sbn2.1`.
+  static final assetFileRegex = RegExp(r'\.sbn2?\.[\dp]+$');
 
   static Future<void> init({
     String? documentsDirectory,
@@ -248,13 +248,20 @@ class FileManager {
     broadcastFileWrite(FileOperationType.write, toPath);
 
     if (alsoMoveAssets && !assetFileRegex.hasMatch(fromPath)) {
-      final assets = <int>[];
+      final assets = <String>[];
       for (int assetNumber = 0; true; assetNumber++) {
         final assetFile = getFile('$fromPath.$assetNumber');
         if (assetFile.existsSync()) {
-          assets.add(assetNumber);
+          assets.add('$assetNumber');
         } else {
           break;
+        }
+      }
+      {
+        const assetNumber = 'p';
+        final assetFile = getFile('$fromPath.$assetNumber');
+        if (assetFile.existsSync()) {
+          assets.add(assetNumber);
         }
       }
 

--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -639,9 +639,6 @@ class FileManager {
   }
 
   static Future _renameReferences(String fromPath, String toPath) async {
-    // rename file in cache
-    PreviewCard.moveFileInCache(fromPath, toPath);
-
     // rename file in recently accessed
     bool replaced = false;
     for (int i = 0; i < Prefs.recentFiles.value.length; i++) {

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -18,7 +18,6 @@ import 'package:saber/components/canvas/canvas_gesture_detector.dart';
 import 'package:saber/components/canvas/canvas_image.dart';
 import 'package:saber/components/canvas/image/editor_image.dart';
 import 'package:saber/components/canvas/save_indicator.dart';
-import 'package:saber/components/home/preview_card.dart';
 import 'package:saber/components/navbar/responsive_navbar.dart';
 import 'package:saber/components/theming/adaptive_alert_dialog.dart';
 import 'package:saber/components/theming/adaptive_icon.dart';
@@ -195,7 +194,7 @@ class EditorState extends State<Editor> {
   }
 
   void _initAsync() async {
-    coreInfo = PreviewCard.getCachedCoreInfo(await widget.initialPath);
+    coreInfo.filePath = await widget.initialPath;
     filenameTextEditingController.text = coreInfo.fileName;
 
     if (needsNaming) {
@@ -856,6 +855,7 @@ class EditorState extends State<Editor> {
       ),
     );
     await FileManager.writeFile(
+      // Note that this ends with .sbn2.png
       '$filePath.png',
       thumbnail,
       awaitWrite: true,

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -16,6 +16,7 @@ import 'package:saber/components/canvas/_stroke.dart';
 import 'package:saber/components/canvas/canvas.dart';
 import 'package:saber/components/canvas/canvas_gesture_detector.dart';
 import 'package:saber/components/canvas/canvas_image.dart';
+import 'package:saber/components/canvas/canvas_preview.dart';
 import 'package:saber/components/canvas/image/editor_image.dart';
 import 'package:saber/components/canvas/save_indicator.dart';
 import 'package:saber/components/navbar/responsive_navbar.dart';
@@ -847,12 +848,19 @@ class EditorState extends State<Editor> {
     if (!mounted) return;
     final screenshotter = ScreenshotController();
     final pageSize = coreInfo.pages.first.size;
+    final thumbnailSize = Size(720, 720 * pageSize.height / pageSize.width);
     final thumbnail = await screenshotter.captureFromWidget(
-      SizedBox(
-        width: 720,
-        height: 720 * pageSize.height / pageSize.width,
-        child: pageBuilder(context, 0),
+      Localizations.override(
+        context: context,
+        child: SizedBox(
+          width: thumbnailSize.width,
+          height: thumbnailSize.height,
+          child: pagePreviewBuilder(context, 0),
+        ),
       ),
+      pixelRatio: 1,
+      context: context,
+      targetSize: thumbnailSize,
     );
     await FileManager.writeFile(
       // Note that this ends with .sbn2.png
@@ -1707,6 +1715,18 @@ class EditorState extends State<Editor> {
         setState(() {});
       },
       currentToolIsSelect: currentTool is Select,
+    );
+  }
+
+  Widget pagePreviewBuilder(BuildContext context, int pageIndex) {
+    final page = coreInfo.pages[pageIndex];
+    final previewHeight = page.previewHeight(
+      lineHeight: coreInfo.lineHeight,
+    );
+    return CanvasPreview(
+      pageIndex: pageIndex,
+      height: previewHeight,
+      coreInfo: coreInfo,
     );
   }
 

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -863,8 +863,8 @@ class EditorState extends State<Editor> {
       targetSize: thumbnailSize,
     );
     await FileManager.writeFile(
-      // Note that this ends with .sbn2.png
-      '$filePath.png',
+      // Note that this ends with .sbn2.p
+      '$filePath.p',
       thumbnail,
       awaitWrite: true,
     );

--- a/test/fm_assets_regex_test.dart
+++ b/test/fm_assets_regex_test.dart
@@ -25,5 +25,9 @@ void main() {
       expect(FileManager.assetFileRegex.hasMatch('2023.11.30'), false);
       expect(FileManager.assetFileRegex.hasMatch('name.sbn3.0'), false);
     });
+    test('matches previews', () {
+      expect(FileManager.assetFileRegex.hasMatch('name.sbn.p'), true);
+      expect(FileManager.assetFileRegex.hasMatch('name.sbn2.p'), true);
+    });
   });
 }


### PR DESCRIPTION
<img src="https://github.com/saber-notes/saber/assets/21128619/5a3e3297-6a0b-4946-b3fc-cf1fe0408870" width=400>


### Tasks
- [X] Take screenshots
- [X] Display screenshots and invert them if needed
- [x] Fix the "_elements.contains(element)" Flutter assertion
- [x] Don't display screenshots as separate files in recent notes/browse pages
- [x] Fallback to old method if thumbnail file doesn't exist