### PR TITLE
fix(browse): deselect after deleting selected files

### DIFF
--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -228,6 +228,7 @@ class _BrowsePageState extends State<BrowsePage> {
                                       ? Editor.extensionOldJson
                                       : Editor.extension))),
                   ]);
+                  selectedFiles.value = [];
                 },
                 icon: const Icon(Icons.delete_forever),
               ),


### PR DESCRIPTION
This fixes the deselection of files after deleting them in the "Browse" tab.  571d571 only fixes it in the "Recent notes" tab.