### PR TITLE
fix: unselect notes after moving

### DIFF
--- a/lib/components/home/masonry_files.dart
+++ b/lib/components/home/masonry_files.dart
@@ -38,6 +38,7 @@ class _MasonryFilesState extends State<MasonryFiles> {
 
   @override
   Widget build(BuildContext context) {
+    isAnythingSelected.value = widget.selectedFiles.value.isNotEmpty;
     /// List of file paths with ads inserted every [itemsBeforeAd] items
     /// (ads are represented by null).
     final List<String?> files = List.from(widget.files);

--- a/lib/components/home/move_note_button.dart
+++ b/lib/components/home/move_note_button.dart
@@ -10,9 +10,11 @@ class MoveNoteButton extends StatelessWidget {
   const MoveNoteButton({
     super.key,
     required this.filesToMove,
+    required this.unselectNotes,
   });
 
   final List<String> filesToMove;
+  final void Function() unselectNotes;
 
   @override
   Widget build(BuildContext context) {
@@ -25,6 +27,7 @@ class MoveNoteButton extends StatelessWidget {
           builder: (BuildContext context) {
             return _MoveNoteDialog(
               filesToMove: filesToMove,
+              unselectNotes: unselectNotes,
             );
           },
         );
@@ -39,9 +42,11 @@ class _MoveNoteDialog extends StatefulWidget {
     // ignore: unused_element
     super.key,
     required this.filesToMove,
+    required this.unselectNotes,
   });
 
   final List<String> filesToMove;
+  final void Function() unselectNotes;
 
   @override
   State<_MoveNoteDialog> createState() => _MoveNoteDialogState();
@@ -248,6 +253,7 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
                 '$currentFolder${newFileNames[i]}$extension',
               );
             }
+            widget.unselectNotes();
             if (!mounted) return;
             Navigator.of(context).pop();
           },

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -213,6 +213,7 @@ class _BrowsePageState extends State<BrowsePage> {
                   )),
               MoveNoteButton(
                 filesToMove: selectedFiles.value,
+                unselectNotes: () => selectedFiles.value = [],
               ),
               IconButton(
                 padding: EdgeInsets.zero,

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -182,6 +182,7 @@ class _RecentPageState extends State<RecentPage> {
               ),
               MoveNoteButton(
                 filesToMove: selectedFiles.value,
+                unselectNotes: () => selectedFiles.value = [],
               ),
               IconButton(
                 padding: EdgeInsets.zero,


### PR DESCRIPTION
This fixes unselecting notes after moving them. Also this fixes a bug which caused the first click on a note after deleting selected notes to result in the note being selected instead of opened in the editor.