### PR TITLE
fix: unselect notes after renaming

### DIFF
--- a/lib/components/home/rename_note_button.dart
+++ b/lib/components/home/rename_note_button.dart
@@ -12,9 +12,11 @@ class RenameNoteButton extends StatelessWidget {
   const RenameNoteButton({
     super.key,
     required this.existingPath,
+    required this.unselectNotes,
   });
 
   final String existingPath;
+  final void Function() unselectNotes;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +29,7 @@ class RenameNoteButton extends StatelessWidget {
           builder: (BuildContext context) {
             return _RenameNoteDialog(
               existingPath: existingPath,
+              unselectNotes: unselectNotes,
             );
           },
         );
@@ -41,9 +44,11 @@ class _RenameNoteDialog extends StatefulWidget {
     // ignore: unused_element
     super.key,
     required this.existingPath,
+    required this.unselectNotes,
   });
 
   final String existingPath;
+  final void Function() unselectNotes;
 
   @override
   State<_RenameNoteDialog> createState() => _RenameNoteDialogState();
@@ -126,6 +131,7 @@ class _RenameNoteDialogState extends State<_RenameNoteDialog> {
             }
             if (!context.mounted) return;
             Navigator.of(context).pop();
+            widget.unselectNotes();
           },
           child: Text(t.home.renameNote.rename),
         ),

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -210,6 +210,7 @@ class _BrowsePageState extends State<BrowsePage> {
                     existingPath: selectedFiles.value.isEmpty
                         ? ''
                         : selectedFiles.value.first,
+                    unselectNotes: () => selectedFiles.value = [],
                   )),
               MoveNoteButton(
                 filesToMove: selectedFiles.value,

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -178,6 +178,7 @@ class _RecentPageState extends State<RecentPage> {
                   existingPath: selectedFiles.value.isEmpty
                       ? ''
                       : selectedFiles.value.first,
+                  unselectNotes: () => selectedFiles.value = [],
                 ),
               ),
               MoveNoteButton(


### PR DESCRIPTION
This fixes unselecting notes after renaming them.