### PR TITLE
perf: avoid `MediaQuery.of`

### DIFF
--- a/lib/components/canvas/canvas_gesture_detector.dart
+++ b/lib/components/canvas/canvas_gesture_detector.dart
@@ -322,7 +322,7 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
       CanvasGestureDetector.scrollToPage(
         pageIndex: widget.initialPageIndex!,
         pages: widget.pages,
-        screenWidth: MediaQuery.of(context).size.width,
+        screenWidth: MediaQuery.sizeOf(context).width,
         transformationController: widget._transformationController,
       );
     }
@@ -406,7 +406,7 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
 
   @override
   Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
 
     return Stack(
       children: [

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -74,7 +74,7 @@ class _PreviewCardState extends State<PreviewCard> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final disableAnimations = MediaQuery.of(context).disableAnimations;
+    final disableAnimations = MediaQuery.disableAnimationsOf(context);
     final transitionDuration =
         Duration(milliseconds: disableAnimations ? 0 : 300);
     final invert =

--- a/lib/components/navbar/responsive_navbar.dart
+++ b/lib/components/navbar/responsive_navbar.dart
@@ -79,7 +79,7 @@ class _ResponsiveNavbarState extends State<ResponsiveNavbar> {
   @override
   Widget build(BuildContext context) {
     ResponsiveNavbar.isLargeScreen = switch (Prefs.layoutSize.value) {
-      LayoutSize.auto => MediaQuery.of(context).size.width >= 600,
+      LayoutSize.auto => MediaQuery.sizeOf(context).width >= 600,
       LayoutSize.phone => false,
       LayoutSize.tablet => true,
     };

--- a/lib/components/settings/settings_selection.dart
+++ b/lib/components/settings/settings_selection.dart
@@ -65,8 +65,7 @@ class _SettingsSelectionState<T extends num>
     icon ??= widget.iconBuilder?.call(widget.pref.value);
     icon ??= Icons.settings;
 
-    final mediaQuery = MediaQuery.of(context);
-    final useDropdownInstead = mediaQuery.size.width < 450;
+    final useDropdownInstead = MediaQuery.sizeOf(context).width < 450;
 
     return ListTile(
       onTap: () {

--- a/lib/components/theming/sliver_width_box.dart
+++ b/lib/components/theming/sliver_width_box.dart
@@ -12,7 +12,7 @@ class SliverWidthBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final windowSize = MediaQuery.of(context).size;
+    final windowSize = MediaQuery.sizeOf(context);
     return SliverPadding(
       padding: EdgeInsets.symmetric(
         horizontal:

--- a/lib/components/toolbar/editor_page_manager.dart
+++ b/lib/components/toolbar/editor_page_manager.dart
@@ -1,5 +1,3 @@
-import 'dart:js';
-
 import 'package:flutter/cupertino.dart' show CupertinoIcons;
 import 'package:flutter/material.dart';
 import 'package:saber/components/canvas/_stroke.dart';

--- a/lib/components/toolbar/editor_page_manager.dart
+++ b/lib/components/toolbar/editor_page_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:js';
+
 import 'package:flutter/cupertino.dart' show CupertinoIcons;
 import 'package:flutter/material.dart';
 import 'package:saber/components/canvas/_stroke.dart';
@@ -40,7 +42,7 @@ class _EditorPageManagerState extends State<EditorPageManager> {
   void scrollToPage(int pageIndex) => CanvasGestureDetector.scrollToPage(
         pageIndex: pageIndex,
         pages: widget.coreInfo.pages,
-        screenWidth: MediaQuery.of(context).size.width,
+        screenWidth: MediaQuery.sizeOf(context).width,
         transformationController: widget.transformationController,
       );
 

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:js';
 
 import 'package:collapsible/collapsible.dart';
 import 'package:file_picker/file_picker.dart';

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:js';
 
 import 'package:collapsible/collapsible.dart';
 import 'package:file_picker/file_picker.dart';
@@ -319,12 +320,12 @@ class EditorState extends State<Editor> {
       late final topOfLastPage = -CanvasGestureDetector.getTopOfPage(
         pageIndex: coreInfo.pages.length - 1,
         pages: coreInfo.pages,
-        screenWidth: MediaQuery.of(context).size.width,
+        screenWidth: MediaQuery.sizeOf(context).width,
       );
       final bottomOfLastPage = -CanvasGestureDetector.getTopOfPage(
         pageIndex: coreInfo.pages.length,
         pages: coreInfo.pages,
-        screenWidth: MediaQuery.of(context).size.width,
+        screenWidth: MediaQuery.sizeOf(context).width,
       );
 
       if (scrollY < bottomOfLastPage) {
@@ -1578,7 +1579,7 @@ class EditorState extends State<Editor> {
                       CanvasGestureDetector.scrollToPage(
                         pageIndex: currentPageIndex + 1,
                         pages: coreInfo.pages,
-                        screenWidth: MediaQuery.of(context).size.width,
+                        screenWidth: MediaQuery.sizeOf(context).width,
                         transformationController: _transformationController,
                       );
                     }),
@@ -1887,7 +1888,7 @@ class EditorState extends State<Editor> {
   int get currentPageIndex {
     if (!mounted) return _lastCurrentPageIndex;
 
-    final screenWidth = MediaQuery.of(context).size.width;
+    final screenWidth = MediaQuery.sizeOf(context).width;
 
     return _lastCurrentPageIndex = getPageIndexFromScrollPosition(
       scrollY: -scrollY,

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -107,7 +107,7 @@ class _BrowsePageState extends State<BrowsePage> {
       title += ': $path';
     }
 
-    final crossAxisCount = MediaQuery.of(context).size.width ~/ 300 + 1;
+    final crossAxisCount = MediaQuery.sizeOf(context).width ~/ 300 + 1;
 
     return Scaffold(
       body: RefreshIndicator(

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -73,7 +73,7 @@ class _HomePageState extends State<HomePage> {
                 Expanded(child: body),
                 SafeArea(
                   child: BannerAdWidget.adaptive(
-                    screenWidth: MediaQuery.of(context).size.width,
+                    screenWidth: MediaQuery.sizeOf(context).width,
                   ),
                 ),
               ],

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -109,7 +109,7 @@ class _RecentPageState extends State<RecentPage> {
     final platform = Theme.of(context).platform;
     final cupertino =
         platform == TargetPlatform.iOS || platform == TargetPlatform.macOS;
-    final crossAxisCount = MediaQuery.of(context).size.width ~/ 300 + 1;
+    final crossAxisCount = MediaQuery.sizeOf(context).width ~/ 300 + 1;
     return Scaffold(
       body: RefreshIndicator(
         onRefresh: () => Future.wait([


### PR DESCRIPTION
For example, instead of `MediaQuery.of(context).size` now we will use `MediaQuery.sizeOf(context)`

Which will listen for only size changes to reduce the rebuilds and help improving the performance