### PR TITLE
fix: use filepaths as cache keys, not File objects

### DIFF
--- a/lib/components/canvas/_asset_cache.dart
+++ b/lib/components/canvas/_asset_cache.dart
@@ -55,13 +55,18 @@ class AssetCache {
   /// Returns whether the image was present in the cache.
   bool removeImage(EditorImage image) {
     if (!allowRemovingAssets) return false;
-    for (final file in _images.keys) {
-      if (_images[file]!.remove(image)) {
-        _images.remove(file);
-        _cache.remove(file);
+
+    for (final filePath in _images.keys) {
+      final imagesUsingFile = _images[filePath]!;
+      imagesUsingFile.remove(image);
+
+      if (imagesUsingFile.isEmpty) {
+        _images.remove(filePath);
+        _cache.remove(filePath);
         return true;
       }
     }
+
     return false;
   }
 

--- a/lib/components/canvas/_asset_cache.dart
+++ b/lib/components/canvas/_asset_cache.dart
@@ -16,12 +16,19 @@ import 'package:logging/logging.dart';
 class AssetCache {
   AssetCache();
   static final log = Logger('AssetCache');
-
   /// Maps a file to its value.
   final Map<String, Object> _cache = {};
 
   /// Maps a file to the visible images that use it.
   final Map<String, Set<EditorImage>> _images = {};
+
+  bool EnabledRemove=true;  // if EnabledRemove then items from cache can be removed. During File save is set to false
+  bool get GetEnabledRemove=>EnabledRemove;
+
+  set SetEnabledRemove(bool EnabledRemoveIn){
+    EnabledRemove=EnabledRemoveIn;
+  }
+
 
   /// Marks [image] as currently visible.
   ///
@@ -49,6 +56,10 @@ class AssetCache {
   ///
   /// Returns whether the image was present in the cache.
   bool removeImage(EditorImage image) {
+    if (!EnabledRemove){
+      // removing from cache is disabled, probably saving to file and cannot manipulate cache
+      return false;
+    }
     for (final file in _images.keys) {
       if (_images[file]!.remove(image)) {
         _images.remove(file);

--- a/lib/components/canvas/_asset_cache.dart
+++ b/lib/components/canvas/_asset_cache.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/painting.dart';
-import 'package:saber/components/canvas/image/editor_image.dart';
 import 'package:logging/logging.dart';
+import 'package:saber/components/canvas/image/editor_image.dart';
 
 /// A cache for assets that are loaded from disk.
 ///

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -827,9 +827,11 @@ class EditorState extends State<Editor> {
     }
 
     final filePath = coreInfo.filePath + Editor.extension;
+    coreInfo.assetCache.SetEnabledRemove=false;  // disable removing from AssetCache during file is saved
     final (bson, assets) = coreInfo.saveToBinary(
       currentPageIndex: currentPageIndex,
     );
+    coreInfo.assetCache.SetEnabledRemove=true;  // enable removing from AssetCache because assets are already set
     try {
       await Future.wait([
         FileManager.writeFile(filePath, bson, awaitWrite: true),

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -12,6 +12,7 @@ import 'package:flutter_quill/flutter_quill.dart' as flutter_quill;
 import 'package:keybinder/keybinder.dart';
 import 'package:logging/logging.dart';
 import 'package:printing/printing.dart';
+import 'package:saber/components/canvas/_asset_cache.dart';
 import 'package:saber/components/canvas/_stroke.dart';
 import 'package:saber/components/canvas/canvas.dart';
 import 'package:saber/components/canvas/canvas_gesture_detector.dart';
@@ -827,11 +828,16 @@ class EditorState extends State<Editor> {
     }
 
     final filePath = coreInfo.filePath + Editor.extension;
-    coreInfo.assetCache.SetEnabledRemove=false;  // disable removing from AssetCache during file is saved
-    final (bson, assets) = coreInfo.saveToBinary(
-      currentPageIndex: currentPageIndex,
-    );
-    coreInfo.assetCache.SetEnabledRemove=true;  // enable removing from AssetCache because assets are already set
+    final Uint8List bson;
+    final OrderedAssetCache assets;
+    coreInfo.assetCache.allowRemovingAssets = false;
+    try {
+      (bson, assets) = coreInfo.saveToBinary(
+        currentPageIndex: currentPageIndex,
+      );
+    } finally {
+      coreInfo.assetCache.allowRemovingAssets = true;
+    }
     try {
       await Future.wait([
         FileManager.writeFile(filePath, bson, awaitWrite: true),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -163,7 +163,7 @@ packages:
     source: hosted
     version: "1.0.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -143,6 +143,8 @@ dependencies:
 
   mutex: ^3.1.0
 
+  collection: ^1.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This commit fixes handling of Assets caches

1. AssetCache - key is now set to File.path (String) because File was incorrectly checked for presence in AssetCache
2. OrderedAssetCache - in add function is sometimes set index of (pdf) asset to -1 even if it is the same as already stored. So additional check is implemented to return asset.
3. Added bool EnabledRemove to AssetCache. It is used to block removing of asset during note is saved.

Closes #1066  (I hope)