### PR TITLE
fix: ignore NaN points on pdf export

### DIFF
--- a/lib/components/canvas/_stroke.dart
+++ b/lib/components/canvas/_stroke.dart
@@ -261,11 +261,19 @@ class Stroke {
           '${page.size.height - point.dy}';
     }
 
-    if (polygon.isEmpty) {
-      return '';
-    } else {
-      return "M${polygon.map((point) => toSvgPoint(point)).join("L")}";
+    if (polygon.isNotEmpty) {
+      String path = polygon
+          // Remove points with NaN values
+          .where((element) => !(element.dy.isNaN || element.dx.isNaN))
+          .map((point) => toSvgPoint(point))
+          .join('L');
+
+      if (path.isNotEmpty) {
+        return 'M$path';
+      }
     }
+
+    return '';
   }
 
   double get maxY {

--- a/lib/components/canvas/_stroke.dart
+++ b/lib/components/canvas/_stroke.dart
@@ -261,19 +261,11 @@ class Stroke {
           '${page.size.height - point.dy}';
     }
 
-    if (polygon.isNotEmpty) {
-      String path = polygon
-          // Remove points with NaN values
-          .where((element) => !(element.dy.isNaN || element.dx.isNaN))
-          .map((point) => toSvgPoint(point))
-          .join('L');
+    // Remove NaN points, and convert to SVG coordinates
+    final svgPoints =
+        polygon.where((offset) => offset.isFinite).map(toSvgPoint);
 
-      if (path.isNotEmpty) {
-        return 'M$path';
-      }
-    }
-
-    return '';
+    return svgPoints.isNotEmpty ? 'M${svgPoints.join('L')}' : '';
   }
 
   double get maxY {


### PR DESCRIPTION
While converting points to SVG path, the condition where dx and dy values of points are NaN isn't checked. So path returned by toSvgPath() becomes something like `MNanNaNLNaNNaN`  which is invalid.This is the reason why PDF exports are failing. I have fixed that by filtering out NaN values.

![image](https://github.com/saber-notes/saber/assets/46302068/98399252-abff-4be6-bff8-05c77a21cd05)


Closes https://github.com/saber-notes/saber/issues/1026
Closes https://github.com/saber-notes/saber/issues/1125