### PR TITLE
perf: don't create thumbnails when auto-saving

### DIFF
--- a/lib/components/canvas/save_indicator.dart
+++ b/lib/components/canvas/save_indicator.dart
@@ -37,7 +37,7 @@ class SaveIndicator extends StatelessWidget {
     );
   }
 
-  void _onPressed(BuildContext context) {
+  void _onPressed(BuildContext context) {// pressed "Save"/"Exit" button
     switch (savingState.value) {
       case SavingState.waitingToSave:
         triggerSave();
@@ -46,7 +46,7 @@ class SaveIndicator extends StatelessWidget {
       case SavingState.saved:
         _back(context);
       case SavingState.savedNeedThumbnailUpdate:
-        triggerSave(); // triggering save will be created thumbnail
+        triggerSave(); // triggering save will be created thumbnail and then is finished editing
         _back(context);
     }
   }

--- a/lib/components/canvas/save_indicator.dart
+++ b/lib/components/canvas/save_indicator.dart
@@ -28,8 +28,8 @@ class SaveIndicator extends StatelessWidget {
             icon: switch (savingState.value) {
               SavingState.waitingToSave => const Icon(Icons.save),
               SavingState.saving => const CircularProgressIndicator.adaptive(),
-              SavingState.saved => const Icon(Icons.arrow_back),
-              SavingState.savedNeedThumbnailUpdate => const Icon(Icons.arrow_back),
+              SavingState.savedWithoutThumbnail => const Icon(Icons.arrow_back),
+              SavingState.savedWithThumbnail => const Icon(Icons.arrow_back),
             },
           ),
         );
@@ -37,16 +37,17 @@ class SaveIndicator extends StatelessWidget {
     );
   }
 
-  void _onPressed(BuildContext context) {// pressed "Save"/"Exit" button
+  /// When the save/exit button is pressed
+  void _onPressed(BuildContext context) {
     switch (savingState.value) {
       case SavingState.waitingToSave:
         triggerSave();
       case SavingState.saving:
         break;
-      case SavingState.saved:
-        _back(context);
-      case SavingState.savedNeedThumbnailUpdate:
+      case SavingState.savedWithoutThumbnail:
         triggerSave(); // triggering save will be created thumbnail and then is finished editing
+        _back(context);
+      case SavingState.savedWithThumbnail:
         _back(context);
     }
   }
@@ -66,6 +67,11 @@ class SaveIndicator extends StatelessWidget {
 enum SavingState {
   waitingToSave,
   saving,
-  saved,
-  savedNeedThumbnailUpdate,  // when saved using autosave and thumbnail was not updated
+
+  /// Saved, but the thumbnail still needs updating.
+  /// (Thumbnails aren't created when auto-saving to avoid lag.)
+  savedWithoutThumbnail,
+
+  /// Saved, and the thumbnail is up-to-date.
+  savedWithThumbnail,
 }

--- a/lib/components/canvas/save_indicator.dart
+++ b/lib/components/canvas/save_indicator.dart
@@ -29,6 +29,7 @@ class SaveIndicator extends StatelessWidget {
               SavingState.waitingToSave => const Icon(Icons.save),
               SavingState.saving => const CircularProgressIndicator.adaptive(),
               SavingState.saved => const Icon(Icons.arrow_back),
+              SavingState.savedNeedThumbnailUpdate => const Icon(Icons.arrow_back),
             },
           ),
         );
@@ -43,6 +44,9 @@ class SaveIndicator extends StatelessWidget {
       case SavingState.saving:
         break;
       case SavingState.saved:
+        _back(context);
+      case SavingState.savedNeedThumbnailUpdate:
+        triggerSave(); // triggering save will be created thumbnail
         _back(context);
     }
   }
@@ -63,4 +67,5 @@ enum SavingState {
   waitingToSave,
   saving,
   saved,
+  savedNeedThumbnailUpdate,  // when saved using autosave and thumbnail was not updated
 }

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -54,7 +54,8 @@ class _PreviewCardState extends State<PreviewCard> {
 
   StreamSubscription? fileWriteSubscription;
   void fileWriteListener(FileOperation event) {
-    if (event.filePath != widget.filePath) return;
+    /// listen to changes of note preview (thumbnail) file to see if it needs to be updated
+    if (event.filePath != '${widget.filePath}${Editor.extension}.p') return;
     if (event.type == FileOperationType.delete) {
       thumbnail.image = null;
     } else if (event.type == FileOperationType.write) {

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -53,9 +53,11 @@ class _PreviewCardState extends State<PreviewCard> {
   }
 
   StreamSubscription? fileWriteSubscription;
+
+  /// Listen to changes of thumbnail file
   void fileWriteListener(FileOperation event) {
-    /// listen to changes of note preview (thumbnail) file to see if it needs to be updated
     if (event.filePath != '${widget.filePath}${Editor.extension}.p') return;
+
     if (event.type == FileOperationType.delete) {
       thumbnail.image = null;
     } else if (event.type == FileOperationType.write) {

--- a/lib/components/navbar/responsive_navbar.dart
+++ b/lib/components/navbar/responsive_navbar.dart
@@ -64,6 +64,7 @@ class _ResponsiveNavbarState extends State<ResponsiveNavbar> {
       switch (savingState) {
         case null:
         case SavingState.saved:
+        case SavingState.savedNeedThumbnailUpdate:
           break;
         case SavingState.waitingToSave:
           Whiteboard.triggerSave();

--- a/lib/components/navbar/responsive_navbar.dart
+++ b/lib/components/navbar/responsive_navbar.dart
@@ -63,8 +63,8 @@ class _ResponsiveNavbarState extends State<ResponsiveNavbar> {
       final savingState = Whiteboard.savingState;
       switch (savingState) {
         case null:
-        case SavingState.saved:
-        case SavingState.savedNeedThumbnailUpdate:
+        case SavingState.savedWithoutThumbnail:
+        case SavingState.savedWithThumbnail:
           break;
         case SavingState.waitingToSave:
           Whiteboard.triggerSave();

--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -28,6 +28,8 @@ class FileManager {
   /// Realistically, this value never changes.
   static late String documentsDirectory;
 
+  /// A stream of [FileOperation]s. Note that file paths
+  /// include the file extension.
   static final StreamController<FileOperation> fileWriteStream =
       StreamController.broadcast(
     onListen: () => _fileWriteStreamIsListening = true,
@@ -73,14 +75,6 @@ class FileManager {
   @visibleForTesting
   static void broadcastFileWrite(FileOperationType type, String path) async {
     if (!_fileWriteStreamIsListening) return;
-
-    // remove extension
-    if (path.endsWith(Editor.extension)) {
-      path = path.substring(0, path.length - Editor.extension.length);
-    } else if (path.endsWith(Editor.extensionOldJson)) {
-      path = path.substring(0, path.length - Editor.extensionOldJson.length);
-    }
-
     fileWriteStream.add(FileOperation(type, path));
   }
 

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -888,7 +888,11 @@ class EditorState extends State<Editor> {
     );
     final thumbnailSize = Size(720, 720 * previewHeight / page.size.width);
     final thumbnail = await screenshotter.captureFromWidget(
-      TranslationProvider(
+      MediaQuery(
+        data: MediaQueryData(
+          size: thumbnailSize,
+          devicePixelRatio: 1,
+        ),
         child: MaterialApp(
           theme: ThemeData(
             brightness: Brightness.light,
@@ -897,12 +901,7 @@ class EditorState extends State<Editor> {
               secondary: EditorExporter.secondaryColor,
             ),
           ),
-          home: MediaQuery(
-            data: MediaQueryData(
-              size: thumbnailSize,
-              devicePixelRatio: 1,
-            ),
-            child: SizedBox(
+          home: SizedBox(
               width: thumbnailSize.width,
               height: thumbnailSize.height,
               child: FittedBox(
@@ -916,7 +915,6 @@ class EditorState extends State<Editor> {
               ),
             ),
           ),
-        ),
       ),
       pixelRatio: 1,
       targetSize: thumbnailSize,

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -258,7 +258,8 @@ class EditorState extends State<Editor> {
       clearAllPages();
 
       // save cleared whiteboard
-      await saveToFile();
+      // without thumbanil as whiteboard thumbnail is never used
+      await saveToFile(createThumbnail: false);
       Whiteboard.needsToAutoClearWhiteboard = false;
     } else {
       setState(() {});
@@ -810,7 +811,7 @@ class EditorState extends State<Editor> {
     });
   }
 
-  Future<void> saveToFile({bool createThumbnail = true}) async {
+  Future<void> saveToFile({required bool createThumbnail}) async {
     // createThumbnail=false is used when called from autosave - to avoid lagging during thumbnail creation
     if (coreInfo.readOnly) return;
 
@@ -876,8 +877,8 @@ class EditorState extends State<Editor> {
     }
   }
 
+  /// create thumbnail of note
   Future<void> createThumbnailPreview() async {
-    /// create Thumbnail of note
     if (coreInfo.readOnly) return;
     final filePath = coreInfo.filePath + Editor.extension;
 
@@ -1579,7 +1580,7 @@ class EditorState extends State<Editor> {
             switch (savingState) {
               case SavingState.waitingToSave:
                 assert(!didPop);
-                saveToFile(); // trigger save now
+                saveToFile(createThumbnail: true); // trigger save now
                 snackBarNeedsToSaveBeforeExiting();
               case SavingState.saving:
                 assert(!didPop);
@@ -1614,7 +1615,7 @@ class EditorState extends State<Editor> {
                       ),
                 leading: SaveIndicator(
                   savingState: savingState,
-                  triggerSave: saveToFile,
+                  triggerSave: () => saveToFile(createThumbnail: true),
                 ),
                 actions: [
                   IconButton(
@@ -1980,7 +1981,7 @@ class EditorState extends State<Editor> {
         await _renameFileNow();
         filenameTextEditingController.dispose();
       }
-      await saveToFile();
+      await saveToFile(createThumbnail: true);
     })();
 
     DynamicMaterialApp.removeFullscreenListener(_setState);

--- a/lib/pages/home/whiteboard.dart
+++ b/lib/pages/home/whiteboard.dart
@@ -21,7 +21,7 @@ class Whiteboard extends StatelessWidget {
     final editorState = _whiteboardKey.currentState;
     if (editorState == null) return;
     assert(editorState.savingState.value == SavingState.waitingToSave);
-    editorState.saveToFile();
+    editorState.saveToFile(createThumbnail: false);
     editorState.snackBarNeedsToSaveBeforeExiting();
   }
 

--- a/test/editor_undo_redo_test.dart
+++ b/test/editor_undo_redo_test.dart
@@ -112,7 +112,7 @@ void main() {
     // save file now to supersede the save timer (which would run after the test is finished)
     printOnFailure('Saving file: $filePath${Editor.extension}');
     await tester.runAsync(() async {
-      await editorState.saveToFile();
+      await editorState.saveToFile(createThumbnail: false);
       await Future.delayed(const Duration(milliseconds: 100));
       await FileManager.deleteFile(filePath + Editor.extension);
     });

--- a/test/editor_undo_redo_test.dart
+++ b/test/editor_undo_redo_test.dart
@@ -61,6 +61,11 @@ void main() {
         reason: 'Editor is still read-only');
     printOnFailure('Editor core info is loaded');
 
+    addTearDown(() async {
+      editorState.delayedSaveTimer?.cancel();
+      await FileManager.deleteFile(filePath + Editor.extension);
+    });
+
     IconButton getUndoBtn() => tester.widget<IconButton>(find.ancestor(
           of: find.byIcon(Icons.undo),
           matching: find.byType(IconButton),
@@ -108,14 +113,6 @@ void main() {
         reason: 'Undo button should be enabled after undo and draw');
     expect(getRedoBtn().onPressed, isNull,
         reason: 'Redo button should be disabled after undo and draw');
-
-    // save file now to supersede the save timer (which would run after the test is finished)
-    printOnFailure('Saving file: $filePath${Editor.extension}');
-    await tester.runAsync(() async {
-      await editorState.saveToFile(createThumbnail: false);
-      await Future.delayed(const Duration(milliseconds: 100));
-      await FileManager.deleteFile(filePath + Editor.extension);
-    });
   });
 }
 

--- a/test/fm_write_stream_test.dart
+++ b/test/fm_write_stream_test.dart
@@ -32,7 +32,7 @@ void main() {
 
       // check that the event was received
       expect(events.length, 1);
-      expect(events.last.filePath, '/test'); // without the extension
+      expect(events.last.filePath, '/test.sbn2');
       expect(events.last.type, FileOperationType.write);
     });
 
@@ -50,7 +50,7 @@ void main() {
       await file.writeAsString('test_content');
       await Future.delayed(const Duration(milliseconds: 100));
       expect(events.length, greaterThanOrEqualTo(2));
-      expect(events.last.filePath, '/test'); // without the extension
+      expect(events.last.filePath, '/test.sbn2');
       expect(events.last.type, FileOperationType.write);
       events.clear();
 
@@ -58,7 +58,7 @@ void main() {
       await file.delete();
       await Future.delayed(const Duration(milliseconds: 100));
       expect(events.length, greaterThanOrEqualTo(1));
-      expect(events.last.filePath, '/test'); // without the extension
+      expect(events.last.filePath, '/test.sbn2');
       expect(events.last.type, FileOperationType.delete);
     });
   });


### PR DESCRIPTION
When note is autosaved, there is no need to create a thumbnail which causes small lag during hang writing.

New SavingState.savedNeedThumbnailUpdate  state is implemented indicating that note is saved but thumbnail is not created.

On editor exit is checked this state and thumbnail is created.  

PreviewCard fileWriteListener is listening to write to thumbnail file to be able to detect change of thumbnail itself.

Closes #1164 (or at least lag is smaller)