### PR TITLE
fix: validate name after dispose

### DIFF
--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -921,7 +921,8 @@ class EditorState extends State<Editor> {
     final newName = filenameTextEditingController.text;
     if (newName == coreInfo.fileName) return;
 
-    if (_validateFilenameTextField(newName) == null) {
+    if (_filenameFormKey.currentState?.validate() ??
+        _validateFilenameTextField(newName) == null) {
       coreInfo.filePath = await FileManager.moveFile(
           coreInfo.filePath + Editor.extension, newName + Editor.extension);
       coreInfo.filePath = coreInfo.filePath

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -831,6 +831,8 @@ class EditorState extends State<Editor> {
         savingState.value = SavingState.saving;
     }
 
+    await _renameFileNow();
+
     final filePath = coreInfo.filePath + Editor.extension;
     final Uint8List bson;
     final OrderedAssetCache assets;

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -919,7 +919,7 @@ class EditorState extends State<Editor> {
     final newName = filenameTextEditingController.text;
     if (newName == coreInfo.fileName) return;
 
-    if (_filenameFormKey.currentState?.validate() ?? true) {
+    if (_validateFilenameTextField(newName) == null) {
       coreInfo.filePath = await FileManager.moveFile(
           coreInfo.filePath + Editor.extension, newName + Editor.extension);
       coreInfo.filePath = coreInfo.filePath


### PR DESCRIPTION
I've noticed that validation of the new name when renaming a note in the editor doesn't work, so you can rename a note to an empty name or a name containing slashes from the editor. The problem was that `_filenameFormKey.currentState?.validate() ?? true` is always a string or true, but it should be false if the function returns null. I've also fixed a bug which made it impossible to save a note after renaming it in the editor but before the new name has been applied.