### PR TITLE
fix: allow selecting new directory that is not empty

### DIFF
--- a/lib/components/settings/settings_directory_selector.dart
+++ b/lib/components/settings/settings_directory_selector.dart
@@ -121,7 +121,13 @@ class _DirectorySelectorState extends State<DirectorySelector> {
   }
 
   void _onConfirm() {
+    if(_isEmpty) {
+      Prefs.customDataDir.removeListener(FileManager.migrateDataDir);
+    }
     Prefs.customDataDir.value = _directory;
+    if(_isEmpty) {
+      Prefs.customDataDir.addListener(FileManager.migrateDataDir);
+    }
     context.pop();
   }
 
@@ -175,7 +181,7 @@ class _DirectorySelectorState extends State<DirectorySelector> {
         ),
         CupertinoDialogAction(
           isDefaultAction: true,
-          onPressed: anyErrors ? null : _onConfirm,
+          onPressed: anyErrors && !emptyError ? null : _onConfirm,
           child: Text(t.settings.customDataDir.select),
         ),
       ],


### PR DESCRIPTION
I know this solution is not ideal, but it makes it possible to recover notes that got lost due to #1228.