### PR TITLE
i18n: Update Czech

### DIFF
--- a/lib/i18n/community/strings_cs.i18n.yaml
+++ b/lib/i18n/community/strings_cs.i18n.yaml
@@ -146,7 +146,7 @@ settings:
     mustBeEmpty: Zvolený adresář musí být prázdný
     mustBeDoneSyncing: "Než změníte datový adresář, ujistěte se, že byla dokončena synchronizace"
 login:
-  title: Přihlásit se
+  title: Přihlášení
   form:
     agreeToPrivacyPolicy(rich): "Přihlášením souhlasíte se ${linkToPrivacyPolicy(Zásadami ochrany osobních údajů)}."
   signup(rich): "Ještě nemáte účet? ${linkToSignup(Zaregistrujte se)}!"
@@ -169,7 +169,7 @@ login:
       followPrompts: Následujte prosím kroky ve webovém prohlížeči
       browserDidntOpen: "Neotevřel se webový prohlížeč? Klepněte zde"
   encLoginStep:
-    enterEncPassword: "Zadejte prosím heslo pro šifrování, abyste chránili svá data:"
+    enterEncPassword: "Pro ochranu svých dat prosím zadejte heslo pro šifrování:"
     newToSaber: "Poprvé v aplikaci Saber? Stačí zadat nové heslo pro šifrování."
     encPassword: Heslo pro šifrování
     encFaqTitle: Často kladené otázky
@@ -178,8 +178,8 @@ login:
     encFaq:
       - q: "Co je to heslo pro šifrování? Proč používat dvě hesla?"
         a: |-
-          Heslo k Nextcloud účtu se používá k přístupu do cloudu. Heslo pro šifrování „zamaskuje“ vaše data dokonce ještě než dorazí na cloud.
-          I když by někdo získat přístup k vašemu Nextcloud účtu, vaše poznámky zůstanou v bezpečí a zašifrované oddělným heslem. To vám přináší druhou úroveň bezpečnosti ochrany vašich dat.
+          Heslo k Nextcloud účtu se používá pro přístup do cloudu. Heslo pro šifrování „zamaskuje“ vaše data dokonce ještě, než dorazí na cloud.
+          I kdyby někdo získal přístup k vašemu Nextcloud účtu, vaše poznámky zůstanou v bezpečí, zašifrované oddělným heslem. To vám přináší druhou úroveň bezpečnosti ochrany vašich dat.
           Nikdo k vašim poznámkám nemůže přistoupit bez hesla pro šifrování, což ale také znamená, že pokud své heslo pro šifrování zapomenete, ztratíte přístup ke svým datům.
       - q: "Ještě jsem heslo pro šifrování nenastavoval. Kde ho získám?"
         a: |-
@@ -204,13 +204,13 @@ profile:
     - q: "Jak změním své heslo pro šifrování?"
       a: |-
         1. Odhlašte se z aplikace Saber. Před odhlášením se ujistěte, že byla dokončena synchronizace a nepřijdete o žádná data (průběh synchronizace uvidíte na domovské obrazovce).
-        2. Přejděte na webovou stránku vašeho serveru a smažte složku 'Saber'. Tím ze serveru odstraníte všechny poznámky.
+        2. Přejděte na webovou stránku vašeho serveru a smažte složku „Saber“. Tím ze serveru odstraníte všechny poznámky.
         3. Opětovně se přihlašte do aplikace Saber. Při přihlašování můžete zvolit nové heslo pro šifrování.
         4. Nezapomeňte se z aplikace Saber odhlásit a opětovně se do ní přihlásit na ostatních zařízeních.
     - q: "Jak odstraním svůj účet?"
       a: |-
-        Klepněte na tlačítko "@:profile.quickLinks.deleteAccount" umístěné výše a přihlašte se, pokud to bude vyžadováno.
-        Pokud používáte výchozí server od aplikace Saber, bude váš účet odstraněn po uplynutí týdenní ochranné lhůty. Během této lhůty mě můžete kontaktovat pro odvolání zrušení účtu na adilhanney@disroot.org.
+        Klepněte na tlačítko „@:profile.quickLinks.deleteAccount“ umístěné výše a přihlašte se, pokud to bude vyžadováno.
+        Pokud používáte oficiální server od aplikace Saber, bude váš účet odstraněn po uplynutí týdenní ochranné lhůty. Během této lhůty mě můžete kontaktovat pro odvolání zrušení účtu na adilhanney@disroot.org.
         Pokud používáte server třetí strany, nemusí nabízet možnost odstranění účtu: pro více informací se bude třeba obrátit na zásady ochrany osobních údajů daného serveru.
 appInfo:
   licenseNotice: |-

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -1884,7 +1884,7 @@ class _StringsLoginCs extends _StringsLoginEn {
 	@override final _StringsCs _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Přihlásit se';
+	@override String get title => 'Přihlášení';
 	@override late final _StringsLoginFormCs form = _StringsLoginFormCs._(_root);
 	@override TextSpan signup({required InlineSpanBuilder linkToSignup}) => TextSpan(children: [
 		const TextSpan(text: 'Ještě nemáte účet? '),
@@ -2281,7 +2281,7 @@ class _StringsLoginEncLoginStepCs extends _StringsLoginEncLoginStepEn {
 	@override final _StringsCs _root; // ignore: unused_field
 
 	// Translations
-	@override String get enterEncPassword => 'Zadejte prosím heslo pro šifrování, abyste chránili svá data:';
+	@override String get enterEncPassword => 'Pro ochranu svých dat prosím zadejte heslo pro šifrování:';
 	@override String get newToSaber => 'Poprvé v aplikaci Saber? Stačí zadat nové heslo pro šifrování.';
 	@override String get encPassword => 'Heslo pro šifrování';
 	@override String get encFaqTitle => 'Často kladené otázky';
@@ -2335,7 +2335,7 @@ class _StringsProfile$faq$0i2$Cs extends _StringsProfile$faq$0i2$En {
 
 	// Translations
 	@override String get q => 'Jak změním své heslo pro šifrování?';
-	@override String get a => '1. Odhlašte se z aplikace Saber. Před odhlášením se ujistěte, že byla dokončena synchronizace a nepřijdete o žádná data (průběh synchronizace uvidíte na domovské obrazovce).\n2. Přejděte na webovou stránku vašeho serveru a smažte složku \'Saber\'. Tím ze serveru odstraníte všechny poznámky.\n3. Opětovně se přihlašte do aplikace Saber. Při přihlašování můžete zvolit nové heslo pro šifrování.\n4. Nezapomeňte se z aplikace Saber odhlásit a opětovně se do ní přihlásit na ostatních zařízeních.';
+	@override String get a => '1. Odhlašte se z aplikace Saber. Před odhlášením se ujistěte, že byla dokončena synchronizace a nepřijdete o žádná data (průběh synchronizace uvidíte na domovské obrazovce).\n2. Přejděte na webovou stránku vašeho serveru a smažte složku „Saber“. Tím ze serveru odstraníte všechny poznámky.\n3. Opětovně se přihlašte do aplikace Saber. Při přihlašování můžete zvolit nové heslo pro šifrování.\n4. Nezapomeňte se z aplikace Saber odhlásit a opětovně se do ní přihlásit na ostatních zařízeních.';
 }
 
 // Path: profile.faq.3
@@ -2346,7 +2346,7 @@ class _StringsProfile$faq$0i3$Cs extends _StringsProfile$faq$0i3$En {
 
 	// Translations
 	@override String get q => 'Jak odstraním svůj účet?';
-	@override String get a => 'Klepněte na tlačítko "${_root.profile.quickLinks.deleteAccount}" umístěné výše a přihlašte se, pokud to bude vyžadováno.\nPokud používáte výchozí server od aplikace Saber, bude váš účet odstraněn po uplynutí týdenní ochranné lhůty. Během této lhůty mě můžete kontaktovat pro odvolání zrušení účtu na adilhanney@disroot.org.\nPokud používáte server třetí strany, nemusí nabízet možnost odstranění účtu: pro více informací se bude třeba obrátit na zásady ochrany osobních údajů daného serveru.';
+	@override String get a => 'Klepněte na tlačítko „${_root.profile.quickLinks.deleteAccount}“ umístěné výše a přihlašte se, pokud to bude vyžadováno.\nPokud používáte oficiální server od aplikace Saber, bude váš účet odstraněn po uplynutí týdenní ochranné lhůty. Během této lhůty mě můžete kontaktovat pro odvolání zrušení účtu na adilhanney@disroot.org.\nPokud používáte server třetí strany, nemusí nabízet možnost odstranění účtu: pro více informací se bude třeba obrátit na zásady ochrany osobních údajů daného serveru.';
 }
 
 // Path: editor.toolbar
@@ -2560,7 +2560,7 @@ class _StringsLoginEncLoginStep$encFaq$0i0$Cs extends _StringsLoginEncLoginStep$
 
 	// Translations
 	@override String get q => 'Co je to heslo pro šifrování? Proč používat dvě hesla?';
-	@override String get a => 'Heslo k Nextcloud účtu se používá k přístupu do cloudu. Heslo pro šifrování „zamaskuje“ vaše data dokonce ještě než dorazí na cloud.\nI když by někdo získat přístup k vašemu Nextcloud účtu, vaše poznámky zůstanou v bezpečí a zašifrované oddělným heslem. To vám přináší druhou úroveň bezpečnosti ochrany vašich dat.\nNikdo k vašim poznámkám nemůže přistoupit bez hesla pro šifrování, což ale také znamená, že pokud své heslo pro šifrování zapomenete, ztratíte přístup ke svým datům.';
+	@override String get a => 'Heslo k Nextcloud účtu se používá pro přístup do cloudu. Heslo pro šifrování „zamaskuje“ vaše data dokonce ještě, než dorazí na cloud.\nI kdyby někdo získal přístup k vašemu Nextcloud účtu, vaše poznámky zůstanou v bezpečí, zašifrované oddělným heslem. To vám přináší druhou úroveň bezpečnosti ochrany vašich dat.\nNikdo k vašim poznámkám nemůže přistoupit bez hesla pro šifrování, což ale také znamená, že pokud své heslo pro šifrování zapomenete, ztratíte přístup ke svým datům.';
 }
 
 // Path: login.encLoginStep.encFaq.1


### PR DESCRIPTION
Hi, @adil192! I'm here with some fixes as I promised in the last pull request!

There is a few things I'd live to fix but I simply can't do it:

1. Some languages (like Czech) uses decimal comma instead of decimal dot (1.21 is correctly 1,21 in Czech). Maybe it could be done just by setting locale in the Flutter or something like that, I don't know.
2. We use a little more strict rules for percentage character. Simply said: we have two meaning for the % char — the meaning without space (21%) is different than meaning with space in between (21 %). So, if you could replace `$percent` with just the number, it will be nice. I need to have usage description typeset as "21 %" (without quotes) for Czech.
3. Czech adds a (unbreakable, but it's not necessary in the context of the mobile app) space between number and its unit (1 s, for example). I found that in app settings, numbers and units are connected together. It has a little different meaning in Czech. Could you divide the number and the unit in the translation string, please?