### PR TITLE
fix: switch SpeedDial label orientation for right-to-left languages

### DIFF
--- a/lib/components/home/export_note_button.dart
+++ b/lib/components/home/export_note_button.dart
@@ -85,6 +85,7 @@ class _ExportNoteButtonState extends State<ExportNoteButton> {
       openCloseDial: isDialOpen,
       childPadding: const EdgeInsets.all(5),
       spaceBetweenChildren: 4,
+      switchLabelPosition: Directionality.of(context) == TextDirection.rtl,
       dialRoot: (context, open, toggleChildren) {
         return _currentlyExporting
             ? const SpinningLoadingIcon()

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -32,6 +32,7 @@ class _NewNoteButtonState extends State<NewNoteButton> {
       openCloseDial: isDialOpen,
       childPadding: const EdgeInsets.all(5),
       spaceBetweenChildren: 4,
+      switchLabelPosition: Directionality.of(context) == TextDirection.rtl,
       dialRoot: (ctx, open, toggleChildren) {
         return FloatingActionButton(
             shape: widget.cupertino ? const CircleBorder() : null,


### PR DESCRIPTION
This fixes #1282 by setting the switchLabelPosition attribute of the SpeedDial accordingly.