### PR TITLE
fix(sync): correct format of decrypted paths

### DIFF
--- a/lib/data/nextcloud/saber_syncer.dart
+++ b/lib/data/nextcloud/saber_syncer.dart
@@ -109,18 +109,9 @@ class SaberSyncInterface
 
   @override
   Future<SaberSyncFile> getSyncFileFromRemoteFile(WebDavFile remoteFile) async {
-    final decryptedPath = await decryptPath(client!, remoteFile.path.path);
-    if (decryptedPath == null)
+    final relativeLocalPath = await decryptPath(client!, remoteFile.path.path);
+    if (relativeLocalPath == null)
       throw Exception('Decryption failed for ${remoteFile.path.path}');
-
-    if (decryptedPath == NextcloudClientExtension.configFileName)
-      return SaberSyncFile(
-        remoteFile: remoteFile,
-        localFile:
-            FileManager.getFile('/${NextcloudClientExtension.configFileName}'),
-      );
-
-    final relativeLocalPath = '${FileManager.documentsDirectory}$decryptedPath';
     final localFile = FileManager.getFile(relativeLocalPath);
 
     return SaberSyncFile(remoteFile: remoteFile, localFile: localFile);

--- a/test/nc_upload_download_test.dart
+++ b/test/nc_upload_download_test.dart
@@ -38,6 +38,14 @@ void main() async {
     expect(upBytes.length, greaterThan(0));
     await syncer.interface.uploadRemoteFile(syncFile, upBytes);
 
+    // Get the sync file again, this time starting with the remote file
+    final remoteFile =
+        await syncer.interface.getWebDavFile(syncFile.remotePath);
+    if (remoteFile == null) fail('Remote file not found after upload');
+    final syncFile2 =
+        await syncer.interface.getSyncFileFromRemoteFile(remoteFile);
+    expect(syncFile2, equals(syncFile));
+
     // Download
     final downBytes = await syncer.interface.downloadRemoteFile(syncFile);
     expect(downBytes.length, greaterThan(0));


### PR DESCRIPTION

A huge thank you to @QubaB for their work finding the problem in #1314

This PR fixes the problem slightly earlier in the syncing process, and adds a test for it

Closes #1306, Closes #1304, Closes #1314