### PR TITLE
snap: fix package name typo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,7 @@ parts:
       - libjsoncpp-dev
       - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
-      - webkit2gtk-4.1-dev
+      - libwebkit2gtk-4.1-dev
     build-snaps:
       - cmake
     stage-packages:


### PR DESCRIPTION
The webkitgtk package name had a typo, this PR fixes it.