### PR TITLE
feat: Added select/deselect all notes button

### DIFF
--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -78,6 +78,7 @@ class _PreviewCardState extends State<PreviewCard> {
 
   @override
   Widget build(BuildContext context) {
+    expanded.value = widget.selected;
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final disableAnimations = MediaQuery.disableAnimationsOf(context);

--- a/lib/components/home/select_all_button.dart
+++ b/lib/components/home/select_all_button.dart
@@ -16,14 +16,18 @@ class SelectAllNotesButton extends StatelessWidget {
   final void Function() deselectAll;
 
   bool get areAllFilesSelected {
-    return selectedFiles.length == allFiles.length;
+    for (String file in allFiles) {
+      if (!selectedFiles.contains(file)) return false;
+    }
+    return true;
   }
 
   @override
   Widget build(BuildContext context) {
     return IconButton(
       padding: EdgeInsets.zero,
-      tooltip: areAllFilesSelected ? t.home.deselectAllNotes : t.home.selectAllNotes ,
+      tooltip:
+          areAllFilesSelected ? t.home.deselectAllNotes : t.home.selectAllNotes,
       onPressed: () {
         if (areAllFilesSelected)
           deselectAll();

--- a/lib/components/home/select_all_button.dart
+++ b/lib/components/home/select_all_button.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:saber/i18n/strings.g.dart';
+
+class SelectAllNotesButton extends StatelessWidget {
+  const SelectAllNotesButton({
+    super.key,
+    required this.selectedFiles,
+    required this.allFiles,
+    required this.selectAll,
+    required this.deselectAll,
+  });
+
+  final List<String> selectedFiles;
+  final List<String> allFiles;
+  final void Function() selectAll;
+  final void Function() deselectAll;
+
+  bool get areAllFilesSelected {
+    return selectedFiles.length == allFiles.length;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      padding: EdgeInsets.zero,
+      tooltip: areAllFilesSelected ? t.home.deselectAllNotes : t.home.selectAllNotes ,
+      onPressed: () {
+        if (areAllFilesSelected)
+          deselectAll();
+        else
+          selectAll();
+      },
+      icon: Icon(areAllFilesSelected ? Icons.deselect : Icons.select_all),
+    );
+  }
+}

--- a/lib/i18n/en.i18n.yaml
+++ b/lib/i18n/en.i18n.yaml
@@ -48,6 +48,8 @@ home:
     renamedTo: Note will be renamed to $newName
     multipleRenamedTo: "The following notes will be renamed:"
     numberRenamedTo: $n notes will be renamed to avoid conflicts
+  selectAllNotes: Select all
+  deselectAllNotes: Deselect all
   deleteNote: Delete note
   renameFolder: 
     renameFolder: Rename folder

--- a/lib/i18n/it.i18n.yaml
+++ b/lib/i18n/it.i18n.yaml
@@ -47,6 +47,8 @@ home:
     renamedTo: La nota verrà rinominata in $newName
     multipleRenamedTo: "Le note seguenti verranno rinominate:"
     numberRenamedTo: $n le note verranno rinominate per evitare conflitti
+  selectAllNotes: Seleziona tutto
+  deselectAllNotes: Deseleziona tutto
   deleteNote: Elimina nota
   renameFolder: 
     renameFolder: Rinomina cartella

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -77,6 +77,8 @@ class TranslationsHomeEn {
 	late final TranslationsHomeNewFolderEn newFolder = TranslationsHomeNewFolderEn.internal(_root);
 	late final TranslationsHomeRenameNoteEn renameNote = TranslationsHomeRenameNoteEn.internal(_root);
 	late final TranslationsHomeMoveNoteEn moveNote = TranslationsHomeMoveNoteEn.internal(_root);
+	String get selectAllNotes => 'Select all';
+	String get deselectAllNotes => 'Deselect all';
 	String get deleteNote => 'Delete note';
 	late final TranslationsHomeRenameFolderEn renameFolder = TranslationsHomeRenameFolderEn.internal(_root);
 	late final TranslationsHomeDeleteFolderEn deleteFolder = TranslationsHomeDeleteFolderEn.internal(_root);

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -74,6 +74,8 @@ class _TranslationsHomeIt extends TranslationsHomeEn {
 	@override late final _TranslationsHomeNewFolderIt newFolder = _TranslationsHomeNewFolderIt._(_root);
 	@override late final _TranslationsHomeRenameNoteIt renameNote = _TranslationsHomeRenameNoteIt._(_root);
 	@override late final _TranslationsHomeMoveNoteIt moveNote = _TranslationsHomeMoveNoteIt._(_root);
+	@override String get selectAllNotes => 'Seleziona tutto';
+	@override String get deselectAllNotes => 'Deseleziona tutto';
 	@override String get deleteNote => 'Elimina nota';
 	@override late final _TranslationsHomeRenameFolderIt renameFolder = _TranslationsHomeRenameFolderIt._(_root);
 	@override late final _TranslationsHomeDeleteFolderIt deleteFolder = _TranslationsHomeDeleteFolderIt._(_root);

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -10,6 +10,7 @@ import 'package:saber/components/home/move_note_button.dart';
 import 'package:saber/components/home/new_note_button.dart';
 import 'package:saber/components/home/no_files.dart';
 import 'package:saber/components/home/rename_note_button.dart';
+import 'package:saber/components/home/select_all_button.dart';
 import 'package:saber/components/home/syncing_button.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/routes.dart';
@@ -30,6 +31,13 @@ class BrowsePage extends StatefulWidget {
 
 class _BrowsePageState extends State<BrowsePage> {
   DirectoryChildren? children;
+
+  List<String> get notesInCwd {
+    return [
+      for (String filePath in children?.files ?? const [])
+        "${path ?? ""}/$filePath",
+    ];
+  }
 
   final List<String?> pathHistory = [];
   String? path;
@@ -185,10 +193,7 @@ class _BrowsePageState extends State<BrowsePage> {
                 ),
                 sliver: MasonryFiles(
                   crossAxisCount: crossAxisCount,
-                  files: [
-                    for (String filePath in children?.files ?? const [])
-                      "${path ?? ""}/$filePath",
-                  ],
+                  files: notesInCwd,
                   selectedFiles: selectedFiles,
                 ),
               ),
@@ -233,6 +238,17 @@ class _BrowsePageState extends State<BrowsePage> {
                   selectedFiles.value = [];
                 },
                 icon: const Icon(Icons.delete_forever),
+              ),
+              SelectAllNotesButton(
+                selectedFiles: selectedFiles.value,
+                allFiles: notesInCwd,
+                selectAll: () => {
+                  selectedFiles.value.clear(),
+                  for (String filePath in notesInCwd)
+                    selectedFiles.value.add(filePath),
+                  setState(() {})
+                },
+                deselectAll: () => {selectedFiles.value = []},
               ),
               ExportNoteButton(
                 selectedFiles: selectedFiles.value,

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -9,6 +9,7 @@ import 'package:saber/components/home/masonry_files.dart';
 import 'package:saber/components/home/move_note_button.dart';
 import 'package:saber/components/home/new_note_button.dart';
 import 'package:saber/components/home/rename_note_button.dart';
+import 'package:saber/components/home/select_all_button.dart';
 import 'package:saber/components/home/syncing_button.dart';
 import 'package:saber/components/home/welcome.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
@@ -202,6 +203,17 @@ class _RecentPageState extends State<RecentPage> {
                   selectedFiles.value = [];
                 },
                 icon: const Icon(Icons.delete_forever),
+              ),
+              SelectAllNotesButton(
+                selectedFiles: selectedFiles.value,
+                allFiles: filePaths,
+                selectAll: () => {
+                  selectedFiles.value.clear(),
+                  for (String file in filePaths)
+                    selectedFiles.value.add(file),
+                  setState(() {}),
+                },
+                deselectAll: () => selectedFiles.value = [],
               ),
               ExportNoteButton(
                 selectedFiles: selectedFiles.value,


### PR DESCRIPTION
Introduced button in recent page footer that allows for selection of all notes

When less than all files are selected
![immagine](https://github.com/user-attachments/assets/dea3e2ba-64b4-4723-a3d4-0ee5296f9a20)

When all files have already been selected, behaviour changes to unselect all
![immagine](https://github.com/user-attachments/assets/3cf91301-023d-487f-bdca-29ccf2beacca)

While implementing this I had to address that newer version of the `saver_gallery` dependency would not compile.
Furthermore `preview_card` makes use of a different variable `expanded` when it actually should never differ from the `widget.selected` one (or else some selection changes do not reflect in the UI). I've kept it for consistency's sake.