### PR TITLE
[onyxsdk_pen] Fix Note Air 3 - Add Hidden API Bypass for SDK30+ and init RxManager

### DIFF
--- a/packages/onyxsdk_pen/android/build.gradle
+++ b/packages/onyxsdk_pen/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.example.onyxsdk_pen'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -36,7 +36,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    namespace 'com.example.onyxsdk_pen'
+    compileSdk 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -56,7 +57,8 @@ android {
     }
 
     dependencies {
-        implementation('com.onyx.android.sdk:onyxsdk-device:1.2.21')
-        implementation('com.onyx.android.sdk:onyxsdk-pen:1.4.4')
+        implementation('com.onyx.android.sdk:onyxsdk-device:1.2.29')
+        implementation('com.onyx.android.sdk:onyxsdk-pen:1.4.10.1')
+        implementation("org.lsposed.hiddenapibypass:hiddenapibypass:4.3")
     }
 }

--- a/packages/onyxsdk_pen/android/src/main/AndroidManifest.xml
+++ b/packages/onyxsdk_pen/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.onyxsdk_pen">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenPlugin.kt
+++ b/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenPlugin.kt
@@ -1,12 +1,14 @@
 package com.example.onyxsdk_pen
 
 import androidx.annotation.NonNull
+import com.onyx.android.sdk.rx.RxManager
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 
 /** OnyxsdkPenPlugin */
 class OnyxsdkPenPlugin: FlutterPlugin, MethodCallHandler {
@@ -19,6 +21,10 @@ class OnyxsdkPenPlugin: FlutterPlugin, MethodCallHandler {
   override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(binding.binaryMessenger, "onyxsdk_pen")
     channel.setMethodCallHandler(this)
+
+    // Needed for new Onyx devices
+    RxManager.Builder.initAppContext(binding.applicationContext)
+    checkHiddenApiBypass()
 
     binding
       .platformViewRegistry
@@ -35,5 +41,11 @@ class OnyxsdkPenPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+  }
+
+  private fun checkHiddenApiBypass() {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+      HiddenApiBypass.addHiddenApiExemptions("")
+    }
   }
 }

--- a/packages/onyxsdk_pen/example/android/app/build.gradle
+++ b/packages/onyxsdk_pen/example/android/app/build.gradle
@@ -11,22 +11,16 @@ if (flutterRoot == null) {
     throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
-}
+def flutterVersionCode = localProperties.getProperty('flutter.versionCode') ?: '1'
+def flutterVersionName = localProperties.getProperty('flutter.versionName') ?: '1.0'
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    namespace 'com.example.onyxsdk_pen_example'
+    compileSdk flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/packages/onyxsdk_pen/example/android/app/src/debug/AndroidManifest.xml
+++ b/packages/onyxsdk_pen/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.onyxsdk_pen_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/onyxsdk_pen/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/onyxsdk_pen/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.onyxsdk_pen_example">
+    xmlns:tools="http://schemas.android.com/tools">
    <application
         android:label="onyxsdk_pen_example"
         android:name="${applicationName}"

--- a/packages/onyxsdk_pen/example/android/app/src/profile/AndroidManifest.xml
+++ b/packages/onyxsdk_pen/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.onyxsdk_pen_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/onyxsdk_pen/example/android/build.gradle
+++ b/packages/onyxsdk_pen/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,7 @@ allprojects {
 }
 
 rootProject.buildDir = '../build'
+
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }
@@ -33,6 +34,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/onyxsdk_pen/example/android/gradle.properties
+++ b/packages/onyxsdk_pen/example/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/packages/onyxsdk_pen/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/onyxsdk_pen/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/packages/onyxsdk_pen/example/lib/main.dart
+++ b/packages/onyxsdk_pen/example/lib/main.dart
@@ -7,7 +7,9 @@ You should be able to smoothly draw on the screen with your stylus.
 With your finger, it'll be as laggy as a regular app.
 ''';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await OnyxSdkPenArea.init();
   runApp(const MyApp());
 }
 


### PR DESCRIPTION
This PR adds support for the Onyx Boox Note Air 3.

Seems like SDK30+ adds some trouble for the Onyx SDK and this "HiddenAPIBypass" is their work-around.

A big thank you to [aarontharris](https://github.com/aarontharris) who did the most work with his PR https://github.com/olup/notable/pull/36. 

I also updated the gradle to be more up to date. Let me know if that is okay or that I need to revert that.