### PR TITLE
Change github ref of `receive_sharing_intent` to a fork which still exists

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1376,9 +1376,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: deec27f3dd36d6c9f51c22d0026baa7b6f0850a3
-      resolved-ref: deec27f3dd36d6c9f51c22d0026baa7b6f0850a3
-      url: "https://github.com/ad-angelo/receive_sharing_intent"
+      ref: HEAD
+      resolved-ref: "2cea396843cd3ab1b5ec4334be4233864637874e"
+      url: "https://github.com/RedC4ke/receive_sharing_intent"
     source: git
     version: "1.8.1"
   regexed_validator:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -177,8 +177,7 @@ dependency_overrides:
   # https://github.com/KasemJaffer/receive_sharing_intent/pull/333
   receive_sharing_intent:
     git:
-      url: https://github.com/ad-angelo/receive_sharing_intent
-      ref: deec27f3dd36d6c9f51c22d0026baa7b6f0850a3
+      url: https://github.com/RedC4ke/receive_sharing_intent
 
   # https://github.com/fluttercommunity/flutter_workmanager/issues/588
   workmanager:


### PR DESCRIPTION
Looks like https://github.com/ad-angelo/receive_sharing_intent has vanished! Until @KasemJaffer does another release, I couldn't build this package on linux without switching this ref. It might be worth hosting our own fork so this doesn't happen again?