### PR TITLE
feat: Improve onyxsdk-pen integration

### DIFF
--- a/lib/components/canvas/canvas.dart
+++ b/lib/components/canvas/canvas.dart
@@ -6,7 +6,13 @@ import 'package:saber/components/canvas/image/editor_image.dart';
 import 'package:saber/components/canvas/inner_canvas.dart';
 import 'package:saber/data/editor/editor_core_info.dart';
 import 'package:saber/data/editor/page.dart';
+import 'package:saber/data/tools/_tool.dart';
+import 'package:saber/data/tools/highlighter.dart';
+import 'package:saber/data/tools/eraser.dart';
+import 'package:saber/data/tools/pencil.dart';
+import 'package:saber/data/tools/laser_pointer.dart';
 import 'package:saber/data/tools/select.dart';
+import 'package:saber/data/tools/pen.dart';
 
 class Canvas extends StatelessWidget {
   const Canvas({
@@ -20,7 +26,7 @@ class Canvas extends StatelessWidget {
     required this.currentStrokeDetectedShape,
     required this.currentSelection,
     required this.setAsBackground,
-    required this.currentToolIsSelect,
+    required this.currentTool,
     required this.currentScale,
     this.placeholder = false,
   });
@@ -37,12 +43,54 @@ class Canvas extends StatelessWidget {
 
   final void Function(EditorImage image)? setAsBackground;
 
-  final bool currentToolIsSelect;
+  final Tool currentTool;
   final double currentScale;
   final bool placeholder;
 
+  int toolToOnyx(Tool currentTool) {
+    if (placeholder) return 5;
+    if (currentTool is Pencil) {
+      return 3;
+    } else if (currentTool is Highlighter) {
+      return 4;
+    } else if (currentTool is Eraser) {
+      return 4;
+    } else if (currentTool is Select) {
+      return 3;
+    } else if (currentTool is LaserPointer) {
+      return 4;
+    } else if (currentTool is Pen) {
+      if ((currentTool as Pen).isPressureEnabled()) {
+        return 0;
+      } else {
+        return 1;
+      }
+    } else {
+      return 5;
+    }
+  }
+
+  int getColor() {
+      if (currentTool is Pen) {
+        var color = (currentTool as Pen).color.toARGB32();
+      	print('color is $color');
+        return color;
+      } else {
+        return 0;
+      }
+  }
+  double getWidth() {
+      if (currentTool is Highlighter) {
+        print('highlighter detected');
+        return 50.0;
+      } else {
+        return 5;
+      }
+  }
+  
   @override
   Widget build(BuildContext context) {
+    print('currentTool: $currentTool');
     return Center(
       child: FittedBox(
         child: DecoratedBox(
@@ -62,6 +110,10 @@ class Canvas extends StatelessWidget {
                     width: page.size.width,
                     height: page.size.height,
                     child: OnyxSdkPenArea(
+		      refreshDelay: const Duration(seconds: 1),
+		      strokeStyle: toolToOnyx(currentTool),
+		      strokeColor: getColor(),
+		      strokeWidth: getWidth(),
                       child: InnerCanvas(
                         key: page.innerCanvasKey,
                         pageIndex: pageIndex,
@@ -74,7 +126,7 @@ class Canvas extends StatelessWidget {
                         currentStrokeDetectedShape: currentStrokeDetectedShape,
                         currentSelection: currentSelection,
                         setAsBackground: setAsBackground,
-                        currentToolIsSelect: currentToolIsSelect,
+                        currentToolIsSelect: currentTool is Select,
                         currentScale: currentScale,
                       ),
                     ),

--- a/lib/components/canvas/canvas.dart
+++ b/lib/components/canvas/canvas.dart
@@ -56,9 +56,9 @@ class Canvas extends StatelessWidget {
     } else if (currentTool is Eraser) {
       return 1;
     } else if (currentTool is Select) {
-      return 3;
+      return 1;
     } else if (currentTool is LaserPointer) {
-      return 4;
+      return 1;
     } else if (currentTool is Pen) {
       if ((currentTool as Pen).isPressureEnabled()) {
         return 2;
@@ -72,18 +72,19 @@ class Canvas extends StatelessWidget {
 
   int getColor() {
       if (currentTool is Pen) {
-        var color = (currentTool as Pen).color.toARGB32();
-      	print('color is $color');
-        return color;
+        return (currentTool as Pen).color.toARGB32();
       } else {
-        return 0;
+        return Colors.black.toARGB32();
       }
   }
   double getWidth() {
-      if (currentTool is Highlighter) {
-        return (currentTool as Pen).getSize() * currentScale * 2;
-      } else if (currentTool is Pen) {
-        return (currentTool as Pen).getSize() * currentScale;
+      if (currentTool is Pen) {
+        double baseSize = (currentTool as Pen).getSize() * currentScale;
+        if ((currentTool as Pen).isPressureEnabled()) {
+          return baseSize;
+        } else {
+          return baseSize * 2;
+        }
       } else {
         return 3.0;
       }
@@ -91,7 +92,6 @@ class Canvas extends StatelessWidget {
   
   @override
   Widget build(BuildContext context) {
-    print('currentTool: $currentTool');
     return Center(
       child: FittedBox(
         child: DecoratedBox(
@@ -111,10 +111,10 @@ class Canvas extends StatelessWidget {
                     width: page.size.width,
                     height: page.size.height,
                     child: OnyxSdkPenArea(
-		      refreshDelay: const Duration(seconds: 1),
-		      strokeStyle: toolToOnyx(currentTool),
-		      strokeColor: getColor(),
-		      strokeWidth: getWidth(),
+                      refreshDelay: const Duration(seconds: 1),
+                      strokeStyle: toolToOnyx(currentTool),
+                      strokeColor: getColor(),
+                      strokeWidth: getWidth(),
                       child: InnerCanvas(
                         key: page.innerCanvasKey,
                         pageIndex: pageIndex,

--- a/lib/components/canvas/canvas.dart
+++ b/lib/components/canvas/canvas.dart
@@ -54,14 +54,14 @@ class Canvas extends StatelessWidget {
     } else if (currentTool is Highlighter) {
       return 4;
     } else if (currentTool is Eraser) {
-      return 4;
+      return 1;
     } else if (currentTool is Select) {
       return 3;
     } else if (currentTool is LaserPointer) {
       return 4;
     } else if (currentTool is Pen) {
       if ((currentTool as Pen).isPressureEnabled()) {
-        return 0;
+        return 2;
       } else {
         return 1;
       }
@@ -81,10 +81,11 @@ class Canvas extends StatelessWidget {
   }
   double getWidth() {
       if (currentTool is Highlighter) {
-        print('highlighter detected');
-        return 50.0;
+        return (currentTool as Pen).getSize() * currentScale * 2;
+      } else if (currentTool is Pen) {
+        return (currentTool as Pen).getSize() * currentScale;
       } else {
-        return 5;
+        return 3.0;
       }
   }
   

--- a/lib/data/tools/pen.dart
+++ b/lib/data/tools/pen.dart
@@ -75,6 +75,9 @@ class Pen extends Tool {
   bool isPressureEnabled() {
     return pressureEnabled;
   }
+  double getSize() {
+    return options.size;
+  }
 
   void onDragStart(
       Offset position, EditorPage page, int pageIndex, double? pressure) {

--- a/lib/data/tools/pen.dart
+++ b/lib/data/tools/pen.dart
@@ -72,6 +72,10 @@ class Pen extends Tool {
     _currentPen = currentPen;
   }
 
+  bool isPressureEnabled() {
+    return pressureEnabled;
+  }
+
   void onDragStart(
       Offset position, EditorPage page, int pageIndex, double? pressure) {
     currentStroke = Stroke(

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -1393,7 +1393,7 @@ class EditorState extends State<Editor> {
           currentSelection: null,
           placeholder: true,
           setAsBackground: null,
-          currentToolIsSelect: currentTool is Select,
+          currentTool: currentTool,
           currentScale: double.minPositive,
         );
       },
@@ -1853,7 +1853,7 @@ class EditorState extends State<Editor> {
         autosaveAfterDelay();
         setState(() {});
       },
-      currentToolIsSelect: currentTool is Select,
+      currentTool: currentTool,
       currentScale: _transformationController.value.approxScale,
     );
   }

--- a/packages/onyxsdk_pen/android/build.gradle
+++ b/packages/onyxsdk_pen/android/build.gradle
@@ -57,8 +57,8 @@ android {
     }
 
     dependencies {
-        implementation('com.onyx.android.sdk:onyxsdk-device:1.2.29')
-        implementation('com.onyx.android.sdk:onyxsdk-pen:1.4.10.1')
+        implementation('com.onyx.android.sdk:onyxsdk-device:1.2.32')
+        implementation('com.onyx.android.sdk:onyxsdk-pen:1.4.12')
         implementation("org.lsposed.hiddenapibypass:hiddenapibypass:4.3")
     }
 }

--- a/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenArea.kt
+++ b/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenArea.kt
@@ -5,19 +5,12 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Rect
-import android.util.Log
 import android.view.SurfaceView
 import android.view.View
 import com.onyx.android.sdk.data.note.TouchPoint
 import com.onyx.android.sdk.pen.RawInputCallback
 import com.onyx.android.sdk.pen.TouchHelper
 import com.onyx.android.sdk.pen.data.TouchPointList
-import com.onyx.android.sdk.pen.NeoBrushPen
-import com.onyx.android.sdk.pen.NeoCharcoalPenV2
-import com.onyx.android.sdk.pen.NeoMarkerPen
-import com.onyx.android.sdk.pen.NeoFountainPen
-import com.onyx.android.sdk.pen.NeoPen
-import com.onyx.android.sdk.api.device.epd.EpdController
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -29,72 +22,88 @@ import java.util.TimerTask
 import androidx.annotation.NonNull
 
 internal class OnyxsdkPenArea(context: Context, messenger: BinaryMessenger, id: Int, creationParams: Map<String?, Any?>?) : PlatformView, MethodCallHandler {
+
     enum class StrokeStyle(val Id: Int) {
-	FountainPen(0),
-	Pen(1),
-	Brush(2),
-	Pencil(3),
-	Marker(4)
+        FountainPen(0),
+        Pen(1),
+        Brush(2),
+        Pencil(3),
+        Marker(4)
     }
+
     private val channel: MethodChannel = MethodChannel(messenger, "onyxsdk_pen_area")
+
     companion object {
         private val pointsToRedraw = 20
-
     }
+
     private var strokeWidth = 0.0f
-    var strokeColor = Color.BLACK
-    var strokeStyle = StrokeStyle.FountainPen
+    private var strokeColor = Color.BLACK
+    private var strokeStyle = StrokeStyle.FountainPen
 
     private fun updateStroke(paramsRef: Map<String, Any>?) {
-	/*
-	 Flutter ints are variable width
-	 Personally, I think it is utterly dumb. I hope there is a way to fix
-	 int size in flutter (why would you need 64 bits to store srgb??),
-	 but unless or until there isn't, this stupidity should be performed
-	 */
-	val pureColor = (paramsRef?.get("strokeColor") as? Long)?.toInt()
-			      ?: paramsRef?.get("strokeColor") as? Int
-			      ?: Color.BLACK
-	/*
-	 ONYXSDK Pen saturates the colors. Whatever it deems as "light" (luma < 128?)
-	 gets automagically turned to white. Transparency is also accounted apparently.
-	 Unless this is some case-by-case situation, if resulting color, assuming
-	 being drawn on absolutely white background, with a fully opaque brush
-	 is lighter than a certain unknown arbitrary threshold, it turns white,
-	 otherwise, is saturated to max.
-	 These thoughts are, however, purely observational. Nothing in documentation
-	 says this and no binary artifacts have been decompiled to come to these
-	 conclusions. Thus, feel free to correct my incompetence if I turn out wrong
-	 */
-	var dest = FloatArray(3)
-	Color.RGBToHSV(
-	    Color.red(pureColor),
-	    Color.green(pureColor),
-	    Color.blue(pureColor),
-	    dest
-	)
-	dest[1] = 1.0f /* saturation */
-	/*
-	 I suppose rounding value is reasonable, but I want color to show
-	 So clamp to black if it's visually indistinguishable from black
-	 and to colorful otherwise. E.g. brown will look red instead of black
-	*/
-	if (dest[2] < 0.2) {
-	    dest[2] = 0.0f
-	} else {
-	    dest[2] = 1.0f
-	}
-	strokeColor = Color.HSVToColor(dest)
-	strokeWidth = (paramsRef?.get("strokeWidth") as? Double ?: 3.0).toFloat()
-	strokeStyle = when (paramsRef?.get("strokeStyle") as? Int ?: 0) {
-	    0 -> StrokeStyle.FountainPen
-	    1 -> StrokeStyle.Pen
-	    2 -> StrokeStyle.Brush
-	    3 -> StrokeStyle.Pencil
-	    4 -> StrokeStyle.Marker
-	    else -> StrokeStyle.Pen
-	}
-	Log.d("SABERSTROKEUPDATE", "color: %d, width: %f, style: %s".format(strokeColor, strokeWidth, strokeStyle.name))
+        /*
+         Flutter ints are variable width
+         Personally, I think it is utterly dumb. I hope there is a way to fix
+         int size in flutter (why would you need 64 bits to store srgb??),
+         but unless or until there isn't, this stupidity should be performed
+         */
+        val pureColor = (paramsRef?.get("strokeColor") as? Long)?.toInt()
+                              ?: paramsRef?.get("strokeColor") as? Int
+                              ?: Color.BLACK
+        /*
+         ONYXSDK Pen saturates the colors. Whatever it deems as "light" (luma < 128?)
+         gets automagically turned to white. Transparency is also accounted apparently.
+         Unless this is some case-by-case situation, if resulting color, assuming
+         being drawn on absolutely white background, with a fully opaque brush
+         is lighter than a certain unknown arbitrary threshold, it turns white,
+         otherwise, is saturated to max.
+         These thoughts are, however, purely observational. Nothing in documentation
+         says this and no binary artifacts have been decompiled to come to these
+         conclusions. Thus, feel free to correct my incompetence if I turn out wrong
+         */
+        var dest = FloatArray(3)
+        Color.RGBToHSV(
+            Color.red(pureColor),
+            Color.green(pureColor),
+            Color.blue(pureColor),
+            dest
+        )
+        /*
+         Saturation
+         I suppose clamping is a sound idea, but the extremes to which the lib
+         takes them are unacceptable. Make it white if visually indistinguishable
+         from white and colorful otherwise.
+        */
+        if (dest[1] < 0.05) {
+            dest[1] = 0.0f
+        } else {
+            dest[1] = 1.0f
+        }
+        /*
+         Value
+         I want color to show
+         So clamp to black if it's visually indistinguishable from black
+         and to colorful otherwise. E.g. brown will look red instead of black
+        */
+        if (dest[2] < 0.2) {
+            dest[2] = 0.0f
+        } else {
+            dest[2] = 1.0f
+        }
+        strokeColor = Color.HSVToColor(dest)
+        strokeWidth = (paramsRef?.get("strokeWidth") as? Double ?: 3.0).toFloat()
+        strokeStyle = when (paramsRef?.get("strokeStyle") as? Int ?: 0) {
+            0 -> StrokeStyle.FountainPen
+            1 -> StrokeStyle.Pen
+            2 -> StrokeStyle.Brush
+            3 -> StrokeStyle.Pencil
+            4 -> StrokeStyle.Marker
+            else -> StrokeStyle.Pen
+        }
+        touchHelper.setStrokeStyle(strokeStyleToOnyx(strokeStyle))
+        touchHelper.setStrokeWidth(strokeWidth)
+        touchHelper.setStrokeColor(strokeColor)
     }
 
 
@@ -106,7 +115,6 @@ internal class OnyxsdkPenArea(context: Context, messenger: BinaryMessenger, id: 
     }
 
     private val paint: Paint = Paint()
-    private val deviceMaxPressure = EpdController.getMaxTouchPressure()
     private var pointsSinceLastRedraw = 0
 
     private val currentStroke: ArrayList<TouchPoint> = ArrayList()
@@ -116,10 +124,6 @@ internal class OnyxsdkPenArea(context: Context, messenger: BinaryMessenger, id: 
 
     private val callback: RawInputCallback = object: RawInputCallback() {
         fun reset() {
-	    touchHelper.setStrokeStyle(strokeStyleToOnyx(strokeStyle))
-	    touchHelper.setStrokeWidth(strokeWidth)
-	    touchHelper.setStrokeColor(strokeColor)
-	    
             currentStroke.clear()
             pointsSinceLastRedraw = 0
             drawPreview()
@@ -184,21 +188,21 @@ internal class OnyxsdkPenArea(context: Context, messenger: BinaryMessenger, id: 
     }
 
     private fun strokeStyleToOnyx(style: StrokeStyle): Int {
-	return when (style) {
-	    StrokeStyle.FountainPen -> TouchHelper.STROKE_STYLE_FOUNTAIN
-	    StrokeStyle.Pen -> TouchHelper.STROKE_STYLE_PENCIL
-	    StrokeStyle.Brush -> TouchHelper.STROKE_STYLE_NEO_BRUSH
-	    StrokeStyle.Pencil -> TouchHelper.STROKE_STYLE_CHARCOAL_V2
-	    StrokeStyle.Marker -> TouchHelper.STROKE_STYLE_MARKER
-	}
+        return when (style) {
+            StrokeStyle.FountainPen -> TouchHelper.STROKE_STYLE_FOUNTAIN
+            StrokeStyle.Pen -> TouchHelper.STROKE_STYLE_PENCIL
+            StrokeStyle.Brush -> TouchHelper.STROKE_STYLE_NEO_BRUSH
+            StrokeStyle.Pencil -> TouchHelper.STROKE_STYLE_CHARCOAL
+            StrokeStyle.Marker -> TouchHelper.STROKE_STYLE_MARKER
+        }
     }
 
     fun drawPreview() {
-	currentStroke.clear()
+        currentStroke.clear()
     }
 
     init {
-	channel.setMethodCallHandler(this)
+        channel.setMethodCallHandler(this)
         view.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
             val limit = Rect()
             val exclude = emptyList<Rect>()
@@ -220,13 +224,13 @@ internal class OnyxsdkPenArea(context: Context, messenger: BinaryMessenger, id: 
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-	if (call.method == "updateStroke") {
-	    val params = call.arguments<Map<String, Any>?>()
-	    updateStroke(params)
-	    result.success(null)
-	} else {
-	    result.notImplemented()
-	}
+        if (call.method == "updateStroke") {
+            val params = call.arguments<Map<String, Any>?>()
+            updateStroke(params)
+            result.success(null)
+        } else {
+            result.notImplemented()
+        }
     }
     
     override fun dispose() {

--- a/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenAreaFactory.kt
+++ b/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenAreaFactory.kt
@@ -3,12 +3,13 @@ package com.example.onyxsdk_pen
 import android.content.Context
 import android.view.View
 import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 
-class OnyxsdkPenAreaFactory : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+class OnyxsdkPenAreaFactory(private val messenger: BinaryMessenger) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
         val creationParams = args as Map<String?, Any?>?
-        return OnyxsdkPenArea(context, viewId, creationParams)
+        return OnyxsdkPenArea(context, messenger, viewId, creationParams)
     }
 }

--- a/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenPlugin.kt
+++ b/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenPlugin.kt
@@ -16,7 +16,8 @@ class OnyxsdkPenPlugin: FlutterPlugin, MethodCallHandler {
   ///
   /// This local reference serves to register the plugin with the Flutter Engine and unregister it
   /// when the Flutter Engine is detached from the Activity
-  private lateinit var channel : MethodChannel
+    private lateinit var channel : MethodChannel
+    private lateinit var channelInstance : MethodChannel
 
   override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(binding.binaryMessenger, "onyxsdk_pen")
@@ -28,7 +29,7 @@ class OnyxsdkPenPlugin: FlutterPlugin, MethodCallHandler {
 
     binding
       .platformViewRegistry
-      .registerViewFactory("onyxsdk_pen_area", OnyxsdkPenAreaFactory())
+      .registerViewFactory("onyxsdk_pen_area", OnyxsdkPenAreaFactory(binding.binaryMessenger))
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {

--- a/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenPlugin.kt
+++ b/packages/onyxsdk_pen/android/src/main/kotlin/com/example/onyxsdk_pen/OnyxsdkPenPlugin.kt
@@ -17,7 +17,6 @@ class OnyxsdkPenPlugin: FlutterPlugin, MethodCallHandler {
   /// This local reference serves to register the plugin with the Flutter Engine and unregister it
   /// when the Flutter Engine is detached from the Activity
     private lateinit var channel : MethodChannel
-    private lateinit var channelInstance : MethodChannel
 
   override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(binding.binaryMessenger, "onyxsdk_pen")
@@ -29,7 +28,10 @@ class OnyxsdkPenPlugin: FlutterPlugin, MethodCallHandler {
 
     binding
       .platformViewRegistry
-      .registerViewFactory("onyxsdk_pen_area", OnyxsdkPenAreaFactory(binding.binaryMessenger))
+      .registerViewFactory(
+         "onyxsdk_pen_area",
+         OnyxsdkPenAreaFactory(binding.binaryMessenger)
+      )
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {

--- a/packages/onyxsdk_pen/lib/onyxsdk_pen_area.dart
+++ b/packages/onyxsdk_pen/lib/onyxsdk_pen_area.dart
@@ -94,7 +94,6 @@ class _OnyxSdkPenAreaState extends State<OnyxSdkPenArea> {
   @override
   Widget build(BuildContext context) {
     if (!isOnyxDevice) return widget.child;
-    creationParams.forEach((k, v) => print('$k: $v'));
     return Stack(
       fit: StackFit.expand,
       children: [

--- a/packages/onyxsdk_pen/lib/onyxsdk_pen_area.dart
+++ b/packages/onyxsdk_pen/lib/onyxsdk_pen_area.dart
@@ -12,6 +12,9 @@ class OnyxSdkPenArea extends StatefulWidget {
   const OnyxSdkPenArea({
     super.key,
     this.refreshDelay = const Duration(seconds: 1),
+    this.strokeStyle = 0,
+    this.strokeColor = 0,
+    this.strokeWidth = 3.0,
     required this.child,
   });
 
@@ -21,6 +24,9 @@ class OnyxSdkPenArea extends StatefulWidget {
   /// is still writing, which will make the screen get stuck in a half-drawn
   /// state.
   final Duration refreshDelay;
+  final int strokeStyle;
+  final int strokeColor;
+  final double strokeWidth;
 
   final Widget child;
 
@@ -65,7 +71,11 @@ class _OnyxSdkPenAreaState extends State<OnyxSdkPenArea> {
   /// Parameters to pass to the platform side
   late final creationParams = <String, dynamic>{
     "refreshDelayMs": widget.refreshDelay.inMilliseconds,
+    "strokeStyle": widget.strokeStyle,
+    "strokeColor": widget.strokeColor,
+    "strokeWidth": widget.strokeWidth,
   };
+  late final channel = MethodChannel('onyxsdk_pen_area');
 
   /// This is used in the platform side to register the view.
   static const String viewType = 'onyxsdk_pen_area';
@@ -73,13 +83,18 @@ class _OnyxSdkPenAreaState extends State<OnyxSdkPenArea> {
   @override
   void didUpdateWidget(OnyxSdkPenArea oldWidget) {
     super.didUpdateWidget(oldWidget);
+    
     creationParams['refreshDelayMs'] = widget.refreshDelay.inMilliseconds;
+    creationParams['strokeStyle'] = widget.strokeStyle;
+    creationParams['strokeColor'] = widget.strokeColor;
+    creationParams['strokeWidth'] = widget.strokeWidth;
+    channel.invokeMethod('updateStroke', creationParams);
   }
 
   @override
   Widget build(BuildContext context) {
     if (!isOnyxDevice) return widget.child;
-
+    creationParams.forEach((k, v) => print('$k: $v'));
     return Stack(
       fit: StackFit.expand,
       children: [

--- a/packages/onyxsdk_pen_dummy/lib/onyxsdk_pen_area.dart
+++ b/packages/onyxsdk_pen_dummy/lib/onyxsdk_pen_area.dart
@@ -4,10 +4,17 @@ class OnyxSdkPenArea extends StatelessWidget {
   const OnyxSdkPenArea({
     super.key,
     this.refreshDelay = const Duration(seconds: 1),
+    this.strokeStyle = 0,
+    this.strokeColor = 0,
+    this.strokeWidth = 3.0,
+
     required this.child,
   });
 
   final Duration refreshDelay;
+  final int strokeStyle;
+  final int strokeColor;
+  final double strokeWidth;
 
   final Widget child;
 


### PR DESCRIPTION
### Updated onyxsdk dependencies
Makes stuff work on some newer devices. Don't really know why, but before that, stylus input resulted in full refreshes, as if there were no support for that altogether. This was observed both on Play Store and on local builds. May, but should not break other devices support

### Reworked OnyxsdkPenArea.kt
- Removed explicit drawing
  Much of the stuff done in `drawPreview` had absolutely no effects. Whole magic seems to happen in `TouchHelper`. Removing that manual drawing, again, may break stuff on other devices, but most of the logic remained nonetheless. In case of breakages, should be trivial to bring that stuff back, or, if my intuition is correct, further simplify this class. Would really like to hear some feedback on that removed code if possible
- Established message passing between `OnyxsdkPenArea` and Dart
  In order to modify state of the PlatformView, message passing was required. It is used to update stroke parameters from Flutter UI toolbar to the PlatformView. I see the use as "refreshing" the `creationParams`. Might be useful in the future, both in of itself and as a precedent for other usecases
- Mapped used tools to those in onyxsdk-pen
  This in effect resulted in directly-refreshed preview looking very similar to the underlying image. Most of the tools are practically indistinguishable and are only insignificantly changed in shape (underlying image is less detailed) and, in some cases significantly in color during full refresh (seen on attached video). Exception being the pencil (seen on attached video), but it's still pretty close. Don't think it can get closer without some legally questionable voodoo magic with onyxsdk

### Dart side
  Most are due to preparation of tool parameters to Kotlin side, some are due to canvas being unaware of the tool being used. I tried to make significant changes as close to the actual use as possible, but may have introduced a couple of unnecessary abstractions and translations along the way. Could possibly be done better, but I'm inexperienced in Flutter and Dart. Hopefully the changes are not disruptive


Seems to be doing good on Note Air 4C, but would be good if someone could test on other devices. This does not seem to introduce any slowdowns, does not touch any significant logic and does not introduce any UI changes

[20250320.webm](https://github.com/user-attachments/assets/79328bce-389f-4adb-a063-806cb181de1a)

Great project BTW