### PR TITLE
Fix: Stylus button wrong tool when coming close again

### DIFF
--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -654,7 +654,7 @@ class EditorState extends State<Editor> {
         ));
       } else if (currentTool is Eraser) {
         final erased = (currentTool as Eraser).onDragEnd();
-        if (tmpTool != null &&
+        if (tmpTool != null && currentTool is Eraser &&
             (stylusButtonPressed || Prefs.disableEraserAfterUse.value)) {
           // restore previous tool
           stylusButtonPressed = false;

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -654,7 +654,7 @@ class EditorState extends State<Editor> {
         ));
       } else if (currentTool is Eraser) {
         final erased = (currentTool as Eraser).onDragEnd();
-        if (tmpTool != null && currentTool is Eraser &&
+        if (tmpTool != null &&
             (stylusButtonPressed || Prefs.disableEraserAfterUse.value)) {
           // restore previous tool
           stylusButtonPressed = false;
@@ -738,7 +738,7 @@ class EditorState extends State<Editor> {
         currentTool = Eraser();
         setState(() {});
       } else {
-        if (tmpTool != null) {
+        if (tmpTool != null && currentTool is Eraser) {
           currentTool = tmpTool!;
           tmpTool = null;
           setState(() {});


### PR DESCRIPTION
Closes #1456 

This fixes the behavior described in #1456 by checking if the currentTool is still the eraser before changing back to the tmpTool stored when the stylus button was pressed.