### PR TITLE
Binary sbn

### DIFF
--- a/lib/components/canvas/_circle_stroke.dart
+++ b/lib/components/canvas/_circle_stroke.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:one_dollar_unistroke_recognizer/one_dollar_unistroke_recognizer.dart';
 import 'package:perfect_freehand/perfect_freehand.dart';
 import 'package:saber/components/canvas/_stroke.dart';
+import 'package:saber/data/editor/binary_writer.dart';
 import 'package:saber/data/editor/page.dart';
 import 'package:saber/data/tools/shape_pen.dart';
 
@@ -72,6 +73,77 @@ class CircleStroke extends Stroke {
       'pe': pressureEnabled,
       'c': color.toARGB32(),
     }..addAll(options.toJson());
+  }
+
+  /// Serializes a Stroke object into a compact binary format.
+  @override
+  void toBinary(BinaryWriter writer) {
+    writer.writeString(StrokeBinaryKeys.shape,"circle");
+    writer.writeInt(StrokeBinaryKeys.pageIndex,pageIndex);
+    writer.writeScaledFloat(StrokeBinaryKeys.cx, center.dx);
+    writer.writeScaledFloat(StrokeBinaryKeys.cy, center.dy);
+    writer.writeScaledFloat(StrokeBinaryKeys.r, radius);
+    writer.writeBool(StrokeBinaryKeys.pressureEnabled,pressureEnabled);
+    writer.writeInt(StrokeBinaryKeys.color,color.toARGB32());
+    options.toBinary(writer); // store stroke options
+    // TODO: Add serialization of StrokeOptions if needed
+  }
+
+  /// Deserializes a Stroke object from binary data starting at [offset].
+  factory CircleStroke.fromBinary(BinaryReader reader,
+      {required HasSize page,
+      }){
+    int key;
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.pageIndex) {
+      throw Exception('StrokefromBinary no pageIndex');
+    }
+    final int pageIndex= reader.readIntNoKey();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.cx) {
+      throw Exception('StrokefromBinary no cx');
+    }
+    final double cx= reader.readScaledFloat();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.cy) {
+      throw Exception('StrokefromBinary no cy');
+    }
+    final double cy= reader.readScaledFloat();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.r) {
+      throw Exception('StrokefromBinary no r');
+    }
+    final double r= reader.readScaledFloat();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.pressureEnabled) {
+      throw Exception('StrokefromBinary no pressureEnabled');
+    }
+    final bool pressureEnabled = reader.readBoolNoKey();
+
+    key=reader.readKey();
+    if (key!=StrokeBinaryKeys.color) {
+      throw Exception('StrokefromBinary no color');
+    }
+    final Color color = reader.readColor();
+
+    final options = StrokeOptions.fromBinary(reader); // adjust this as per your needs
+
+    return CircleStroke(
+      color: color,
+      pressureEnabled: pressureEnabled,
+      options: options,
+      pageIndex: pageIndex,
+      page: page,
+      penType: (ShapePen).toString(),
+      center: Offset(cx,cy),
+      radius: r,
+    );
+
   }
 
   @override

--- a/lib/components/canvas/_rectangle_stroke.dart
+++ b/lib/components/canvas/_rectangle_stroke.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:one_dollar_unistroke_recognizer/one_dollar_unistroke_recognizer.dart';
 import 'package:perfect_freehand/perfect_freehand.dart';
 import 'package:saber/components/canvas/_stroke.dart';
+import 'package:saber/data/editor/binary_writer.dart';
 import 'package:saber/data/editor/page.dart';
 import 'package:saber/data/tools/shape_pen.dart';
 
@@ -71,6 +72,89 @@ class RectangleStroke extends Stroke {
       'c': color.toARGB32(),
     }..addAll(options.toJson());
   }
+
+  /// Serializes a Stroke object into a compact binary format.
+  @override
+  void toBinary(BinaryWriter writer) {
+    writer.writeString(StrokeBinaryKeys.shape,"rect");
+    writer.writeInt(StrokeBinaryKeys.pageIndex,pageIndex);
+    writer.writeScaledFloat(StrokeBinaryKeys.left, rect.left);
+    writer.writeScaledFloat(StrokeBinaryKeys.top, rect.top);
+    writer.writeScaledFloat(StrokeBinaryKeys.width, rect.width);
+    writer.writeScaledFloat(StrokeBinaryKeys.height, rect.height);
+    writer.writeBool(StrokeBinaryKeys.pressureEnabled,pressureEnabled);
+    writer.writeInt(StrokeBinaryKeys.color,color.toARGB32());
+    options.toBinary(writer); // store stroke options
+    // TODO: Add serialization of StrokeOptions if needed
+  }
+
+  /// Deserializes a Stroke object from binary data starting at [offset].
+  factory RectangleStroke.fromBinary(BinaryReader reader,
+      {required HasSize page,
+      }){
+    int key;
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.pageIndex) {
+      throw Exception('StrokefromBinary no pageIndex');
+    }
+    final int pageIndex= reader.readIntNoKey();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.left) {
+      throw Exception('StrokefromBinary no left');
+    }
+    final double left= reader.readScaledFloat();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.top) {
+      throw Exception('StrokefromBinary no top');
+    }
+    final double top= reader.readScaledFloat();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.width) {
+      throw Exception('StrokefromBinary no width');
+    }
+    final double width= reader.readScaledFloat();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.height) {
+      throw Exception('StrokefromBinary no height');
+    }
+    final double height= reader.readScaledFloat();
+
+    key = reader.readKey();
+    if (key != StrokeBinaryKeys.pressureEnabled) {
+      throw Exception('StrokefromBinary no pressureEnabled');
+    }
+    final bool pressureEnabled = reader.readBoolNoKey();
+
+    key=reader.readKey();
+    if (key!=StrokeBinaryKeys.color) {
+      throw Exception('StrokefromBinary no color');
+    }
+    final Color color = reader.readColor();
+
+    final options = StrokeOptions.fromBinary(reader); // adjust this as per your needs
+
+    return RectangleStroke(
+      color: color,
+      pressureEnabled: pressureEnabled,
+      options: options,
+      pageIndex: pageIndex,
+      page: page,
+      penType: (ShapePen).toString(),
+      rect: Rect.fromLTWH(
+        left,
+        top,
+        width,
+        height,
+      ),
+    );
+
+  }
+
 
   @override
   bool get isEmpty => rect.isEmpty;

--- a/lib/components/canvas/image/png_editor_image.dart
+++ b/lib/components/canvas/image/png_editor_image.dart
@@ -176,7 +176,7 @@ class PngEditorImage extends EditorImage {
     final Uint8List? bytes;
     File? imageFile;
     if (assetIndex>=0) {
-      if (inlineAssets == null) {
+      if (inlineAssets!.length == 0) {
         imageFile =
             FileManager.getFile('$sbnPath${Editor.extension}.$assetIndex');
         bytes = assetCache.get(imageFile);

--- a/lib/data/editor/binary_writer.dart
+++ b/lib/data/editor/binary_writer.dart
@@ -1,0 +1,241 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/painting.dart';
+
+
+// class used to write binary version of sbn file directly, not using json
+class BinaryWriter {
+
+  // Scale factor to preserve 3 decimal places
+  static const double _scale = 1000.0;
+
+  final BytesBuilder _buffer = BytesBuilder();
+
+  void clear() {
+    _buffer.clear(); // Empties the buffer
+  }
+
+  void writeKey(int key) {
+    _buffer.addByte(key);
+  }
+
+
+  void writeInt(int key, int val) {
+    final b = ByteData(4)..setInt32(0, val, Endian.little);
+    _buffer.addByte(key);
+    _buffer.add(b.buffer.asUint8List());
+  }
+
+  void writeFloat(int key, double val) {
+    final b = ByteData(4)..setFloat32(0, val, Endian.little);
+    _buffer.addByte(key);
+    _buffer.add(b.buffer.asUint8List());
+  }
+
+  void writeScaledFloat(int key, double val) {
+    // used to write positions on canvas to have small file but enough precision
+    int scaledVal = (val * _scale).round();
+    final b = ByteData(4)..setInt32(0, scaledVal, Endian.little);
+    _buffer.addByte(key);
+    _buffer.add(b.buffer.asUint8List());
+  }
+
+
+  void writeDouble(int key, double value) {
+    final b = ByteData(8)..setFloat64(0, value, Endian.little);
+    _buffer.addByte(key);
+    _buffer.add(b.buffer.asUint8List());
+  }
+
+  void writeBool(int key, bool val) {
+    _buffer.addByte(key);
+    _buffer.addByte(val ? 1 : 0);
+  }
+
+  void writeColor(int key, Color? color) {
+    if (color == null) return;  // do not write it
+    writeInt(key, color.toARGB32()); // ARGB32 is just an int
+  }
+
+  void writeString(int key, String value) {
+    final bytes = utf8.encode(value);
+    final lenBytes = ByteData(4)..setUint32(0, bytes.length, Endian.little);
+    _buffer.addByte(key);
+    _buffer.add(lenBytes.buffer.asUint8List());
+    _buffer.add(bytes);
+  }
+
+  void writeEnum(int key, Enum value) {
+    _buffer.addByte(key);
+    _buffer.addByte(value.index);
+  }
+
+  void writeFloatNoKey(double val) {
+    final b = ByteData(4)..setFloat32(0, val, Endian.little);
+    _buffer.add(b.buffer.asUint8List());
+  }
+  void writeScaledFloatNoKey(double val) {
+    // used to write positions on canvas to have small file but enough precision
+    int scaledVal = (val * _scale).round();
+    final b = ByteData(4)..setInt32(0, scaledVal, Endian.little);
+    _buffer.add(b.buffer.asUint8List());
+  }
+  void writeDoubleNoKey(double value) {
+    final b = ByteData(8)..setFloat64(0, value, Endian.little);
+    _buffer.add(b.buffer.asUint8List());
+  }
+  void writeIntNoKey(int val) {
+    final b = ByteData(4)..setInt32(0, val, Endian.little);
+    _buffer.add(b.buffer.asUint8List());
+  }
+  void writeBoolNoKey(bool val) {
+    _buffer.addByte(val ? 1 : 0);
+  }
+
+  void writeStringNoKey(String value) {
+    final bytes = utf8.encode(value);
+    final lenBytes = ByteData(4)..setUint32(0, bytes.length, Endian.little);
+    _buffer.add(lenBytes.buffer.asUint8List());
+    _buffer.add(bytes);
+  }
+
+
+
+  /// Returns the accumulated binary data as a Uint8List
+  Uint8List toBytes() => _buffer.toBytes();
+}
+
+class BinaryReader {
+  late ByteData _data;
+  int _offset = 0;
+
+  BinaryReader(Uint8List buffer) {
+    _data = ByteData.sublistView(buffer);
+  }
+
+  bool get isEOF => _offset >= _data.lengthInBytes;
+
+  int readKey() => _data.getUint8(_offset++);
+
+  int readInt() {
+    final val = _data.getInt32(_offset, Endian.little);
+    _offset += 4;
+    return val;
+  }
+
+  double readFloat() {
+    final val = _data.getFloat32(_offset, Endian.little);
+    _offset += 4;
+    return val;
+  }
+  double readScaledFloat() {
+    final val = _data.getInt32(_offset, Endian.little);
+    _offset += 4;
+    return val / BinaryWriter._scale;
+  }
+
+  bool readBool() => _data.getUint8(_offset++) != 0;
+
+  String readString() {
+    final length = _data.getUint32(_offset, Endian.little);
+    _offset += 4;
+    final bytes = _data.buffer.asUint8List(_offset, length);
+    final str = utf8.decode(bytes);
+    _offset += length;
+    return str;
+  }
+
+  Enum readEnum(List<Enum> values) {
+    final index = _data.getUint8(_offset++);
+    return values[index];
+  }
+
+  int readIntNoKey() => readInt();
+  double readFloatNoKey() => readFloat();
+  bool readBoolNoKey() => readBool();
+  String readStringNoKey() => readString();
+
+  /// Reads color stored as ARGB int
+  Color readColor() => Color(readInt());
+}
+
+abstract class SBNBinaryKeys {
+  static const int version = 1;
+  static const int nextImageId = 2;
+  static const int backgroundColor = 3;
+  static const int backgroundPattern = 4;
+  static const int lineHeight = 5;
+  static const int lineThickness = 6;
+  static const int pages = 122;
+  static const int pageCount = 123;
+  static const int initialPageIndex = 7;
+}
+
+abstract class PageBinaryKeys {
+  static const int version = 1;
+  static const int width = 2;         // 'w'
+  static const int height = 3;        // 'h'
+  static const int strokes = 4;       // 's'
+  static const int images = 5;        // 'i'
+  static const int quill = 6;         // 'q'
+  static const int backgroundImage = 7; // 'b'
+}
+
+abstract class ImageBinaryKeys {
+  static const int version = 1;
+  static const int id = 2;
+  static const int extension = 3;
+  static const int pageIndex = 4;
+  static const int invertible = 5;
+  static const int backgroundFit = 6;
+
+  static const int dstLeft = 7;
+  static const int dstTop = 8;
+  static const int dstWidth = 9;
+  static const int dstHeight = 10;
+
+  static const int srcLeft = 11;
+  static const int srcTop = 12;
+  static const int srcWidth = 13;
+  static const int srcHeight = 14;
+
+  static const int naturalWidth = 15;
+  static const int naturalHeight = 16;
+
+  // Reserved keys for extensions / subclasses
+  static const int imageBytes = 101;
+  static const int assetId = 102;
+  static const int pdfi = 103;
+}
+
+abstract class StrokeBinaryKeys {
+  static const int version = 1;
+  static const int shape = 2;
+  static const int pointCount = 3;
+  static const int pageIndex = 4;
+  static const int penType = 5;
+  static const int pressureEnabled = 6;
+  static const int color = 7;
+  static const int cx = 8;
+  static const int cy = 9;
+  static const int r = 10;
+  static const int left = 11;
+  static const int top = 12;
+  static const int width = 13;
+  static const int height = 14;
+
+  // options
+  static const int size = 101;
+  static const int thinning = 102;
+  static const int smoothing = 103;
+  static const int streamline = 104;
+  static const int startTaperEnabled = 105;
+  static const int startCustomTaper = 106;
+  static const int endTaperEnabled = 107;
+  static const int endCustomTaper = 108;
+  static const int startCap = 109;
+  static const int endCap = 110;
+  static const int simulatePressure = 111;
+  static const int isComplete = 112;
+  static const int endOptions = 130;  // indicate end options
+}

--- a/lib/data/editor/page.dart
+++ b/lib/data/editor/page.dart
@@ -296,7 +296,6 @@ class EditorPage extends Listenable implements HasSize {
 
     final String  quillString;
     final Map<String, dynamic> quillJson;
-    final List? ql;
     key=reader.readKey();
     if (key!=PageBinaryKeys.quill){
       throw Exception('page.fromBinary: quill not set');

--- a/lib/data/prefs.dart
+++ b/lib/data/prefs.dart
@@ -94,6 +94,7 @@ abstract class Prefs {
   static late final PlainPref<int> autosaveDelay;
   static late final PlainPref<int> shapeRecognitionDelay;
   static late final PlainPref<bool> autoStraightenLines;
+  static late final PlainPref<bool> saveAsBinary;
   static late final PlainPref<PencilSoundSetting> pencilSound;
 
   static late final PlainPref<bool> simplifiedHomeLayout;
@@ -205,6 +206,7 @@ abstract class Prefs {
     autosaveDelay = PlainPref('autosaveDelay', 10000);
     shapeRecognitionDelay = PlainPref('shapeRecognitionDelay', 500);
     autoStraightenLines = PlainPref('autoStraightenLines', true);
+    saveAsBinary = PlainPref('saveAsBinary', false);
     pencilSound =
         PlainPref('pencilSound', PencilSoundSetting.onButNotInSilentMode);
 

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -899,9 +899,17 @@ class EditorState extends State<Editor> {
     final OrderedAssetCache assets;
     coreInfo.assetCache.allowRemovingAssets = false;
     try {
-      (bson, assets) = coreInfo.saveToBinary(
-        currentPageIndex: currentPageIndex,
-      );
+      if (false) {
+        (bson, assets) = coreInfo.saveToBinary(
+          currentPageIndex: currentPageIndex,
+        );
+      }
+      else {
+        // save as binary data directly
+        (bson, assets) = coreInfo.toBinary(
+          currentPageIndex: currentPageIndex,
+        );
+      }
     } finally {
       coreInfo.assetCache.allowRemovingAssets = true;
     }

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -899,7 +899,7 @@ class EditorState extends State<Editor> {
     final OrderedAssetCache assets;
     coreInfo.assetCache.allowRemovingAssets = false;
     try {
-      if (false) {
+      if (!Prefs.saveAsBinary.value) {
         (bson, assets) = coreInfo.saveToBinary(
           currentPageIndex: currentPageIndex,
         );

--- a/lib/pages/home/settings.dart
+++ b/lib/pages/home/settings.dart
@@ -516,6 +516,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 pref: Prefs.autoStraightenLines,
               ),
               SettingsSwitch(
+                title: t.settings.prefLabels.saveAsBinary,
+                subtitle: t.settings.prefDescriptions.saveAsBinary,
+                icon: Icons.save_sharp,
+                pref: Prefs.saveAsBinary,
+              ),
+              SettingsSwitch(
                 title: t.settings.prefLabels.simplifiedHomeLayout,
                 subtitle: t.settings.prefDescriptions.simplifiedHomeLayout,
                 iconBuilder: (simplified) =>


### PR DESCRIPTION
This commit implements writing note as binary file. It does not convert note to Json and save Json so especially reading of note is much faster.

When reading note file Json is also not used so reconstruction is faster.  

(Json is only used to save/read quill, i.e. editor).

There is not solved versioning of note file. It means when new version of note will be read by older version of Saber, it will fail to read. 

The purpose of this commit is provide alternative way to save/read note and improve speed of reading.