### PR TITLE
fix: Correct migration procedure

### DIFF
--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -16,6 +16,7 @@ import 'package:saber/i18n/strings.g.dart';
 import 'package:saber/pages/editor/editor.dart';
 import 'package:saver_gallery/saver_gallery.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:path/path.dart' as p;
 
 /// A collection of cross-platform utility functions for working with a virtual file system.
 class FileManager {
@@ -76,7 +77,7 @@ class FileManager {
       log.fine('Old data directory is empty or missing, nothing to migrate');
     } else {
       await moveDirContents(oldDir: oldDir, newDir: newDir);
-      await oldDir.delete();
+      await oldDir.delete(recursive: true);
     }
   }
 
@@ -85,13 +86,33 @@ class FileManager {
     required Directory newDir,
   }) async {
     await newDir.create(recursive: true);
-    await for (final entity in oldDir.list()) {
-      final entityPath = '${newDir.path}/${entity.path.split('/').last}';
-      switch (entity) {
-        case File _:
-          await entity.rename(entityPath);
-        case Directory _:
-          await moveDirContents(oldDir: oldDir, newDir: Directory(entityPath));
+
+    await for (final entity in oldDir.list(recursive: true)) {
+      // Get the path under oldDir and map it into newDir.
+      final relative = p.relative(entity.path, from: oldDir.path);
+      final targetPath = p.join(newDir.path, relative);
+
+      if (entity is Directory) {
+        await Directory(targetPath).create(recursive: true);
+        continue;
+      }
+
+      if (entity is File) {
+        // Ensure parent exists
+        await Directory(p.dirname(targetPath)).create(recursive: true);
+
+        try {
+          await entity.rename(targetPath);
+        } on FileSystemException catch (e) {
+          // Cross device move, eg. private to public on android
+          const exdev = 18;
+          if (e.osError?.errorCode == exdev) {
+            await entity.copy(targetPath);
+            await entity.delete();
+          } else {
+            rethrow;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Otherwise it keeps creating `oldDir`'s child folders inside themselves until the path is too long for the OS to handle.

*May just have lost about a year's worth of notes to this*. Oh well, lesson learned, backup things more throughoutly.

**Note:** I am really against the delete over at
```dart
await moveDirContents(oldDir: oldDir, newDir: newDir);
await oldDir.delete(recursive: true);
```
Existing because it is a ticking timebomb waiting to delete an user's files if they "Allow access" to the wrong folder. The least that should be done is have a checkbox to *optionally* delete the old stuff with the user's consent. May be able to get worked into this PR, lmk your thoughts.