### PR TITLE
fix: Correct stow version in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -146,9 +146,9 @@ dependencies:
   pdfrx: ^2.1.3
   path: ^1.9.1
 
-  stow: ^0.5.0
+  stow: ^0.5.1
   stow_plain: ^0.5.0
-  stow_secure: ^0.5.0
+  stow_secure: ^0.5.1
   stow_codecs: ^1.2.0
 
   sentry_flutter: ^9.5.0


### PR DESCRIPTION
Correct stow versions in pubspec.yaml (not commited in 17370e49d9c30320943ff5932376fc45db92de62)