### PR TITLE
fix: draw dot only if stroke consists of single point

### DIFF
--- a/lib/components/canvas/_canvas_painter.dart
+++ b/lib/components/canvas/_canvas_painter.dart
@@ -135,7 +135,7 @@ class CanvasPainter extends CustomPainter {
           ),
           shapePaint,
         );
-      } else if (stroke.length <= 2) {
+      } else if (stroke.length <= 1) {
         // a dot
         final bounds = stroke.lowQualityPath.getBounds();
         final radius = max(bounds.size.width, stroke.options.size) / 2;


### PR DESCRIPTION
This fixes #1391. Large dots only appear if a stroke consists of exactly two points. But since perfect-freehand can now correctly handle strokes consisting of two points, they don't need to be drawn as dots anymore.