### PR TITLE
Add folder move functionality to browse tab

### DIFF
--- a/lib/components/home/grid_folders.dart
+++ b/lib/components/home/grid_folders.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart' show CupertinoIcons;
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:saber/components/home/delete_folder_button.dart';
+import 'package:saber/components/home/move_folder_button.dart';
 import 'package:saber/components/home/new_folder_dialog.dart';
 import 'package:saber/components/home/rename_folder_button.dart';
 import 'package:saber/components/theming/adaptive_icon.dart';
@@ -20,6 +21,8 @@ class GridFolders extends StatelessWidget {
     required this.deleteFolder,
     required this.doesFolderExist,
     required this.folders,
+    this.currentFolderPath,
+    this.moveFolder,
   });
 
   final bool isAtRoot;
@@ -31,6 +34,12 @@ class GridFolders extends StatelessWidget {
   final Future<void> Function(String oldName, String newName) renameFolder;
   final Future<bool> Function(String) isFolderEmpty;
   final Future<void> Function(String) deleteFolder;
+
+  /// The current folder path (with trailing slash), used for move operation.
+  final String? currentFolderPath;
+
+  /// Callback when a folder is moved. If null, move button won't be shown.
+  final Future<void> Function(String folderName)? moveFolder;
 
   final List<String> folders;
 
@@ -61,6 +70,8 @@ class GridFolders extends StatelessWidget {
             renameFolder: renameFolder,
             isFolderEmpty: isFolderEmpty,
             deleteFolder: deleteFolder,
+            currentFolderPath: currentFolderPath,
+            moveFolder: moveFolder,
             onTap: onTap,
           );
         },
@@ -81,6 +92,8 @@ class _GridFolder extends StatefulWidget {
     required this.isFolderEmpty,
     required this.deleteFolder,
     required this.onTap,
+    this.currentFolderPath,
+    this.moveFolder,
   }) : assert(
          (folderName == null) ^ (cardType == .realFolder),
          'Real folders must specify a folder name',
@@ -93,6 +106,8 @@ class _GridFolder extends StatefulWidget {
   final Future<void> Function(String oldName, String newName) renameFolder;
   final Future<bool> Function(String) isFolderEmpty;
   final Future<void> Function(String) deleteFolder;
+  final String? currentFolderPath;
+  final Future<void> Function(String folderName)? moveFolder;
   final Function(String) onTap;
 
   @override
@@ -210,6 +225,18 @@ class _GridFolderState extends State<_GridFolder> {
                                         expanded.value = false;
                                       },
                                     ),
+                                    if (widget.moveFolder != null &&
+                                        widget.currentFolderPath != null)
+                                      MoveFolderButton(
+                                        folderName: widget.folderName!,
+                                        currentFolder: widget.currentFolderPath!,
+                                        onMoved: () async {
+                                          await widget.moveFolder!(
+                                            widget.folderName!,
+                                          );
+                                          expanded.value = false;
+                                        },
+                                      ),
                                     DeleteFolderButton(
                                       folderName: widget.folderName!,
                                       deleteFolder: (String folderName) async {

--- a/lib/components/home/grid_folders.dart
+++ b/lib/components/home/grid_folders.dart
@@ -229,7 +229,8 @@ class _GridFolderState extends State<_GridFolder> {
                                         widget.currentFolderPath != null)
                                       MoveFolderButton(
                                         folderName: widget.folderName!,
-                                        currentFolder: widget.currentFolderPath!,
+                                        currentFolder:
+                                            widget.currentFolderPath!,
                                         onMoved: () async {
                                           await widget.moveFolder!(
                                             widget.folderName!,

--- a/lib/components/home/move_folder_button.dart
+++ b/lib/components/home/move_folder_button.dart
@@ -56,8 +56,7 @@ class _MoveFolderDialog extends StatefulWidget {
 
 class _MoveFolderDialogState extends State<_MoveFolderDialog> {
   /// The full path of the folder being moved
-  late final sourceFolderPath =
-      '${widget.currentFolder}${widget.folderName}';
+  late final sourceFolderPath = '${widget.currentFolder}${widget.folderName}';
 
   late String _destinationFolder;
 
@@ -217,7 +216,8 @@ class _MoveFolderDialogState extends State<_MoveFolderDialog> {
           onPressed: isInvalidDestination
               ? null
               : () async {
-                  final destinationPath = '$destinationFolder${widget.folderName}';
+                  final destinationPath =
+                      '$destinationFolder${widget.folderName}';
                   await FileManager.moveDirectory(
                     sourceFolderPath,
                     destinationPath,

--- a/lib/components/home/move_folder_button.dart
+++ b/lib/components/home/move_folder_button.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:saber/components/home/grid_folders.dart';
+import 'package:saber/components/theming/adaptive_alert_dialog.dart';
+import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/i18n/strings.g.dart';
+
+class MoveFolderButton extends StatelessWidget {
+  const MoveFolderButton({
+    super.key,
+    required this.folderName,
+    required this.currentFolder,
+    required this.onMoved,
+  });
+
+  final String folderName;
+  final String currentFolder;
+  final void Function() onMoved;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      padding: EdgeInsets.zero,
+      tooltip: t.home.moveFolder.moveFolder,
+      onPressed: () {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return _MoveFolderDialog(
+              folderName: folderName,
+              currentFolder: currentFolder,
+              onMoved: onMoved,
+            );
+          },
+        );
+      },
+      icon: const Icon(Icons.drive_file_move),
+    );
+  }
+}
+
+class _MoveFolderDialog extends StatefulWidget {
+  const _MoveFolderDialog({
+    required this.folderName,
+    required this.currentFolder,
+    required this.onMoved,
+  });
+
+  final String folderName;
+  final String currentFolder;
+  final void Function() onMoved;
+
+  @override
+  State<_MoveFolderDialog> createState() => _MoveFolderDialogState();
+}
+
+class _MoveFolderDialogState extends State<_MoveFolderDialog> {
+  /// The full path of the folder being moved
+  late final sourceFolderPath =
+      '${widget.currentFolder}${widget.folderName}';
+
+  late String _destinationFolder;
+
+  /// The current folder browsed to in the dialog (destination parent folder).
+  String get destinationFolder => _destinationFolder;
+  set destinationFolder(String folder) {
+    _destinationFolder = folder;
+    destinationFolderChildren = null;
+    findChildrenOfDestinationFolder();
+  }
+
+  /// The children of [destinationFolder].
+  DirectoryChildren? destinationFolderChildren;
+
+  /// The final folder name at the destination (might be renamed if conflict).
+  String? newFolderName;
+
+  /// Whether the folder will be renamed due to conflict.
+  bool get willBeRenamed =>
+      newFolderName != null && newFolderName != widget.folderName;
+
+  /// Whether moving to the destination is invalid (moving into itself).
+  bool get isInvalidDestination {
+    final destinationPath = '$destinationFolder${widget.folderName}';
+    // Cannot move a folder into itself or its subdirectory
+    return destinationPath.startsWith('$sourceFolderPath/') ||
+        destinationPath == sourceFolderPath;
+  }
+
+  Future findChildrenOfDestinationFolder() async {
+    destinationFolderChildren = await FileManager.getChildrenOfDirectory(
+      destinationFolder,
+    );
+
+    // Check if folder name conflicts with existing directory
+    if (destinationFolderChildren?.directories.contains(widget.folderName) ??
+        false) {
+      // Find a unique name
+      int i = 2;
+      String candidateName = '${widget.folderName} ($i)';
+      while (destinationFolderChildren?.directories.contains(candidateName) ??
+          false) {
+        i++;
+        candidateName = '${widget.folderName} ($i)';
+      }
+      newFolderName = candidateName;
+    } else {
+      newFolderName = widget.folderName;
+    }
+
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  Future<void> createFolder(String folderName) async {
+    final folderPath = '$destinationFolder$folderName';
+    await FileManager.createFolder(folderPath);
+    findChildrenOfDestinationFolder();
+  }
+
+  @override
+  void initState() {
+    // Start at the parent of the folder's current location
+    destinationFolder = widget.currentFolder;
+    if (!destinationFolder.startsWith('/')) {
+      destinationFolder = '/$destinationFolder';
+    }
+    super.initState();
+
+    findChildrenOfDestinationFolder();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveAlertDialog(
+      title: Text(t.home.moveFolder.moveName(f: widget.folderName)),
+      content: SizedBox(
+        width: 300,
+        height: 300,
+        child: Column(
+          children: [
+            Text(destinationFolder),
+            Expanded(
+              child: CustomScrollView(
+                shrinkWrap: true,
+                slivers: [
+                  GridFolders(
+                    isAtRoot: destinationFolder == '/',
+                    crossAxisCount: 3,
+                    onTap: (String folder) {
+                      setState(() {
+                        if (folder == '..') {
+                          destinationFolder = destinationFolder.substring(
+                            0,
+                            destinationFolder.lastIndexOf(
+                                  '/',
+                                  destinationFolder.length - 2,
+                                ) +
+                                1,
+                          );
+                        } else {
+                          destinationFolder = '$destinationFolder$folder/';
+                        }
+                      });
+                    },
+                    createFolder: createFolder,
+                    doesFolderExist: (String folderName) {
+                      return destinationFolderChildren?.directories.contains(
+                            folderName,
+                          ) ??
+                          false;
+                    },
+                    renameFolder: (String oldName, String newName) async {
+                      final oldPath = '$destinationFolder$oldName';
+                      await FileManager.renameDirectory(oldPath, newName);
+                      findChildrenOfDestinationFolder();
+                    },
+                    isFolderEmpty: (String folderName) async {
+                      final folderPath = '$destinationFolder$folderName';
+                      final children = await FileManager.getChildrenOfDirectory(
+                        folderPath,
+                      );
+                      return children?.isEmpty ?? true;
+                    },
+                    deleteFolder: (String folderName) async {
+                      final folderPath = '$destinationFolder$folderName';
+                      await FileManager.deleteDirectory(folderPath);
+                      findChildrenOfDestinationFolder();
+                    },
+                    folders: [
+                      for (final directoryPath
+                          in destinationFolderChildren?.directories ?? const [])
+                        directoryPath,
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            if (isInvalidDestination)
+              Text(
+                t.home.moveFolder.cantMoveHere,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              )
+            else if (willBeRenamed)
+              Text(t.home.moveFolder.renamedTo(newName: newFolderName!)),
+          ],
+        ),
+      ),
+      actions: [
+        CupertinoDialogAction(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: Text(t.common.cancel),
+        ),
+        CupertinoDialogAction(
+          onPressed: isInvalidDestination
+              ? null
+              : () async {
+                  final destinationPath = '$destinationFolder${widget.folderName}';
+                  await FileManager.moveDirectory(
+                    sourceFolderPath,
+                    destinationPath,
+                  );
+                  widget.onMoved();
+                  if (!context.mounted) return;
+                  Navigator.of(context).pop();
+                },
+          child: Text(t.home.moveFolder.move),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -527,10 +527,7 @@ class FileManager {
   /// suffixed with a number e.g. "folder (2)".
   ///
   /// This method prevents moving a directory into its own subdirectory.
-  static Future<String> moveDirectory(
-    String fromPath,
-    String toPath,
-  ) async {
+  static Future<String> moveDirectory(String fromPath, String toPath) async {
     fromPath = _sanitisePath(fromPath);
     toPath = _sanitisePath(toPath);
 
@@ -554,7 +551,9 @@ class FileManager {
 
     final fromDir = Directory(documentsDirectory + fromPath);
     if (!fromDir.existsSync()) {
-      log.warning('Tried to move non-existent directory from $fromPath to $toPath');
+      log.warning(
+        'Tried to move non-existent directory from $fromPath to $toPath',
+      );
       return toPath;
     }
 
@@ -562,7 +561,9 @@ class FileManager {
     final List<String> children = [];
     await for (final entity in fromDir.list(recursive: true)) {
       if (entity is File) {
-        children.add(entity.path.substring(documentsDirectory.length + fromPath.length));
+        children.add(
+          entity.path.substring(documentsDirectory.length + fromPath.length),
+        );
       }
     }
 

--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -520,6 +520,89 @@ class FileManager {
     await directory.delete(recursive: recursive);
   }
 
+  /// Moves a directory from [fromPath] to [toPath].
+  ///
+  /// Returns the final destination path after the move.
+  /// If a directory already exists at [toPath], the directory name will be
+  /// suffixed with a number e.g. "folder (2)".
+  ///
+  /// This method prevents moving a directory into its own subdirectory.
+  static Future<String> moveDirectory(
+    String fromPath,
+    String toPath,
+  ) async {
+    fromPath = _sanitisePath(fromPath);
+    toPath = _sanitisePath(toPath);
+
+    // Ensure paths don't end with slash for consistent handling
+    if (fromPath.endsWith('/')) {
+      fromPath = fromPath.substring(0, fromPath.length - 1);
+    }
+    if (toPath.endsWith('/')) {
+      toPath = toPath.substring(0, toPath.length - 1);
+    }
+
+    // Prevent moving a directory into itself or its subdirectory
+    if (toPath.startsWith('$fromPath/')) {
+      throw ArgumentError('Cannot move a folder into its own subdirectory');
+    }
+
+    // Make the destination path unique if it already exists
+    toPath = await _suffixDirectoryPathToMakeItUnique(toPath);
+
+    if (fromPath == toPath) return toPath;
+
+    final fromDir = Directory(documentsDirectory + fromPath);
+    if (!fromDir.existsSync()) {
+      log.warning('Tried to move non-existent directory from $fromPath to $toPath');
+      return toPath;
+    }
+
+    // Collect all files in the directory for reference updates
+    final List<String> children = [];
+    await for (final entity in fromDir.list(recursive: true)) {
+      if (entity is File) {
+        children.add(entity.path.substring(documentsDirectory.length + fromPath.length));
+      }
+    }
+
+    // Create the parent directory of the destination if needed
+    final toParentDir = Directory(
+      documentsDirectory + toPath.substring(0, toPath.lastIndexOf('/')),
+    );
+    if (!toParentDir.existsSync()) {
+      await toParentDir.create(recursive: true);
+    }
+
+    // Move the directory
+    await fromDir.rename(documentsDirectory + toPath);
+
+    // Update references and broadcast file operations for all children
+    for (final child in children) {
+      _renameReferences(fromPath + child, toPath + child);
+      broadcastFileWrite(FileOperationType.delete, fromPath + child);
+      broadcastFileWrite(FileOperationType.write, toPath + child);
+    }
+
+    return toPath;
+  }
+
+  /// Returns a unique directory path by appending a number to the end.
+  /// e.g. "/MyFolder" -> "/MyFolder (2)"
+  static Future<String> _suffixDirectoryPathToMakeItUnique(
+    String directoryPath,
+  ) async {
+    String newPath = directoryPath;
+    int i = 1;
+
+    while (Directory(documentsDirectory + newPath).existsSync()) {
+      i++;
+      newPath = '$directoryPath ($i)';
+    }
+
+    return newPath;
+  }
+
   /// Gets the children of a directory, separated into
   /// [DirectoryChildren.directories] and [DirectoryChildren.files].
   ///

--- a/lib/i18n/en.i18n.yaml
+++ b/lib/i18n/en.i18n.yaml
@@ -56,11 +56,17 @@ home:
     folderNameEmpty: Folder name can't be empty
     folderNameContainsSlash: Folder name can't contain a slash
     folderNameExists: A folder with this name already exists
-  deleteFolder: 
+  deleteFolder:
     deleteFolder: Delete folder
     deleteName: Delete $f
     delete: Delete
     alsoDeleteContents: Also delete all notes inside this folder
+  moveFolder:
+    moveFolder: Move folder
+    moveName: Move $f
+    move: Move
+    renamedTo: Folder will be renamed to $newName
+    cantMoveHere: Cannot move folder here
 sentry: 
   consent: 
     title: Help improve Saber?

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -104,6 +104,7 @@ class TranslationsHomeEn {
 
 	late final TranslationsHomeRenameFolderEn renameFolder = TranslationsHomeRenameFolderEn.internal(_root);
 	late final TranslationsHomeDeleteFolderEn deleteFolder = TranslationsHomeDeleteFolderEn.internal(_root);
+	late final TranslationsHomeMoveFolderEn moveFolder = TranslationsHomeMoveFolderEn.internal(_root);
 }
 
 // Path: sentry
@@ -523,6 +524,30 @@ class TranslationsHomeDeleteFolderEn {
 
 	/// en: 'Also delete all notes inside this folder'
 	String get alsoDeleteContents => 'Also delete all notes inside this folder';
+}
+
+// Path: home.moveFolder
+class TranslationsHomeMoveFolderEn {
+	TranslationsHomeMoveFolderEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Move folder'
+	String get moveFolder => 'Move folder';
+
+	/// en: 'Move $f'
+	String moveName({required Object f}) => 'Move ${f}';
+
+	/// en: 'Move'
+	String get move => 'Move';
+
+	/// en: 'Folder will be renamed to $newName'
+	String renamedTo({required Object newName}) => 'Folder will be renamed to ${newName}';
+
+	/// en: 'Cannot move folder here'
+	String get cantMoveHere => 'Cannot move folder here';
 }
 
 // Path: sentry.consent

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -174,6 +174,11 @@ class _BrowsePageState extends State<BrowsePage> {
                 await FileManager.deleteDirectory(folderPath);
                 findChildrenOfPath();
               },
+              currentFolderPath: '${path ?? ''}/'.replaceFirst(RegExp(r'^/+'), '/'),
+              moveFolder: (String folderName) async {
+                // Refresh the folder list after move
+                findChildrenOfPath();
+              },
               folders: [
                 for (final directoryPath in children?.directories ?? const [])
                   directoryPath,

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -174,7 +174,10 @@ class _BrowsePageState extends State<BrowsePage> {
                 await FileManager.deleteDirectory(folderPath);
                 findChildrenOfPath();
               },
-              currentFolderPath: '${path ?? ''}/'.replaceFirst(RegExp(r'^/+'), '/'),
+              currentFolderPath: '${path ?? ''}/'.replaceFirst(
+                RegExp(r'^/+'),
+                '/',
+              ),
               moveFolder: (String folderName) async {
                 // Refresh the folder list after move
                 findChildrenOfPath();


### PR DESCRIPTION
Summary

- Add ability to move entire folders (including subfolders and notes) to a different location
- Long-press a folder in the Browse tab to access the new "Move" button
- Dialog allows browsing and selecting destination folder
- Automatically handles name conflicts by appending a number suffix
- Prevents invalid moves (e.g., moving a folder into itself)

Test plan

- [ ] Long-press a folder and verify the move icon appears between rename and delete
- [ ] Tap move icon and verify destination picker dialog opens
- [ ] Navigate to different folders within the dialog
- [ ] Move a folder to a new location and verify all contents are preserved
- [ ] Attempt to move a folder into its own subfolder and verify error message
- [ ] Move a folder to a location with a same-named folder and verify auto-rename