### PR TITLE
feat: allows scaling eraser with display and shows a dotted circumference around it

### DIFF
--- a/lib/components/canvas/_canvas_painter.dart
+++ b/lib/components/canvas/_canvas_painter.dart
@@ -10,6 +10,7 @@ import 'package:saber/components/canvas/_rectangle_stroke.dart';
 import 'package:saber/components/canvas/_stroke.dart';
 import 'package:saber/data/editor/page.dart';
 import 'package:saber/data/extensions/color_extensions.dart';
+import 'package:saber/data/tools/eraser.dart';
 import 'package:saber/data/tools/highlighter.dart';
 import 'package:saber/data/tools/laser_pointer.dart';
 import 'package:saber/data/tools/select.dart';
@@ -254,7 +255,7 @@ class CanvasPainter extends CustomPainter {
 
   void _drawEraserIndicator(Canvas canvas) {
     if (page.eraserPosition == null) return;
-    final radius = 10.0 / currentScale; // Eraser().size is 10 by default
+    final radius = Eraser().size / currentScale;
 
     final path = Path()
       ..addOval(Rect.fromCircle(center: page.eraserPosition!, radius: radius));

--- a/lib/components/canvas/_canvas_painter.dart
+++ b/lib/components/canvas/_canvas_painter.dart
@@ -55,6 +55,7 @@ class CanvasPainter extends CustomPainter {
     _drawCurrentStroke(canvas);
     _drawDetectedShape(canvas);
     _drawSelection(canvas);
+    _drawEraserIndicator(canvas);
     _drawPageIndicator(canvas, size);
   }
 
@@ -74,7 +75,8 @@ class CanvasPainter extends CustomPainter {
         showPageIndicator != oldDelegate.showPageIndicator ||
         pageIndex != oldDelegate.pageIndex ||
         totalPages != oldDelegate.totalPages ||
-        currentScale != oldDelegate.currentScale;
+        currentScale != oldDelegate.currentScale ||
+        page.eraserPosition != oldDelegate.page.eraserPosition;
   }
 
   void _drawHighlighterStrokes(Canvas canvas, Rect canvasRect) {
@@ -247,6 +249,27 @@ class CanvasPainter extends CustomPainter {
         ..color = primaryColor
         ..strokeWidth = 3
         ..style = .stroke,
+    );
+  }
+
+  void _drawEraserIndicator(Canvas canvas) {
+    if (page.eraserPosition == null) return;
+    final radius = 10.0 / currentScale; // Eraser().size is 10 by default
+
+    final path = Path()
+      ..addOval(
+        Rect.fromCircle(center: page.eraserPosition!, radius: radius),
+      );
+
+    canvas.drawPath(
+      dashPath(
+        path,
+        dashArray: CircularIntervalList([5 / currentScale, 5 / currentScale]),
+      ),
+      Paint()
+        ..color = Colors.grey
+        ..strokeWidth = 1.0 / currentScale
+        ..style = PaintingStyle.stroke,
     );
   }
 

--- a/lib/components/canvas/_canvas_painter.dart
+++ b/lib/components/canvas/_canvas_painter.dart
@@ -257,9 +257,7 @@ class CanvasPainter extends CustomPainter {
     final radius = 10.0 / currentScale; // Eraser().size is 10 by default
 
     final path = Path()
-      ..addOval(
-        Rect.fromCircle(center: page.eraserPosition!, radius: radius),
-      );
+      ..addOval(Rect.fromCircle(center: page.eraserPosition!, radius: radius));
 
     canvas.drawPath(
       dashPath(

--- a/lib/data/editor/page.dart
+++ b/lib/data/editor/page.dart
@@ -28,6 +28,8 @@ class EditorPage extends ChangeNotifier implements HasSize {
   @override
   final Size size;
 
+  Offset? eraserPosition;
+
   late final CanvasKey innerCanvasKey = CanvasKey();
   RenderBox? _renderBox;
   RenderBox? get renderBox {

--- a/lib/data/tools/eraser.dart
+++ b/lib/data/tools/eraser.dart
@@ -23,7 +23,7 @@ class Eraser extends Tool {
   List<Stroke> checkForOverlappingStrokes(
     Offset eraserPos,
     List<Stroke> strokes, {
-    double scale = 1.0,
+    required double scale,
   }) {
     final effectiveSqrSize = sqrSize / square(scale);
     final List<Stroke> overlapping = [];

--- a/lib/data/tools/eraser.dart
+++ b/lib/data/tools/eraser.dart
@@ -22,12 +22,14 @@ class Eraser extends Tool {
   /// Returns any [strokes] that are close to the given [eraserPos].
   List<Stroke> checkForOverlappingStrokes(
     Offset eraserPos,
-    List<Stroke> strokes,
-  ) {
+    List<Stroke> strokes, {
+    double scale = 1.0,
+  }) {
+    final effectiveSqrSize = sqrSize / square(scale);
     final List<Stroke> overlapping = [];
     for (int i = 0; i < strokes.length; i++) {
       final stroke = strokes[i];
-      if (_shouldStrokeBeErased(eraserPos, stroke, sqrSize)) {
+      if (_shouldStrokeBeErased(eraserPos, stroke, effectiveSqrSize)) {
         overlapping.add(stroke);
         _erased.add(stroke);
       }

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -564,6 +564,7 @@ class EditorState extends State<Editor> {
         currentPressure,
       );
     } else if (currentTool is Eraser) {
+      page.eraserPosition = position;
       for (final stroke in (currentTool as Eraser).checkForOverlappingStrokes(
         position,
         page.strokes,
@@ -606,6 +607,7 @@ class EditorState extends State<Editor> {
       (currentTool as Pen).onDragUpdate(position, currentPressure);
       page.redrawStrokes();
     } else if (currentTool is Eraser) {
+      page.eraserPosition = position;
       for (final stroke in (currentTool as Eraser).checkForOverlappingStrokes(
         position,
         page.strokes,
@@ -663,6 +665,7 @@ class EditorState extends State<Editor> {
           ),
         );
       } else if (currentTool is Eraser) {
+        page.eraserPosition = null;
         final erased = (currentTool as Eraser).onDragEnd();
         if (tmpTool != null &&
             (stylusButtonPressed || stows.disableEraserAfterUse.value)) {

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -567,6 +567,7 @@ class EditorState extends State<Editor> {
       for (final stroke in (currentTool as Eraser).checkForOverlappingStrokes(
         position,
         page.strokes,
+        scale: _transformationController.value.approxScale,
       )) {
         page.strokes.remove(stroke);
       }
@@ -608,6 +609,7 @@ class EditorState extends State<Editor> {
       for (final stroke in (currentTool as Eraser).checkForOverlappingStrokes(
         position,
         page.strokes,
+        scale: _transformationController.value.approxScale,
       )) {
         page.strokes.remove(stroke);
       }

--- a/test/tools_eraser_test.dart
+++ b/test/tools_eraser_test.dart
@@ -96,11 +96,9 @@ void main() {
     );
 
     // Check with scale 1.0 (default)
-    var erased = eraser.checkForOverlappingStrokes(
-      _eraserPos,
-      [strokeAtEdge],
-      scale: 1.0,
-    );
+    var erased = eraser.checkForOverlappingStrokes(_eraserPos, [
+      strokeAtEdge,
+    ], scale: 1.0);
     expect(
       erased.contains(strokeAtEdge),
       true,
@@ -108,15 +106,14 @@ void main() {
     );
 
     // Check with scale 2.0 (eraser should be smaller in document coordinates)
-    erased = eraser.checkForOverlappingStrokes(
-      _eraserPos,
-      [strokeAtEdge],
-      scale: 2.0,
-    );
+    erased = eraser.checkForOverlappingStrokes(_eraserPos, [
+      strokeAtEdge,
+    ], scale: 2.0);
     expect(
       erased.contains(strokeAtEdge),
       false,
-      reason: 'Should NOT erase stroke at distance 10 when scale is 2.0 (effective size 5)',
+      reason:
+          'Should NOT erase stroke at distance 10 when scale is 2.0 (effective size 5)',
     );
 
     // At scale 0.5, effective size should be 20.
@@ -124,15 +121,14 @@ void main() {
     final strokeFurtherAway = _strokeWithPoint(
       _eraserPos + const Offset(1.5, 0) * eraser.size,
     );
-    erased = eraser.checkForOverlappingStrokes(
-      _eraserPos,
-      [strokeFurtherAway],
-      scale: 0.5,
-    );
+    erased = eraser.checkForOverlappingStrokes(_eraserPos, [
+      strokeFurtherAway,
+    ], scale: 0.5);
     expect(
       erased.contains(strokeFurtherAway),
       true,
-      reason: 'Should erase stroke at distance 15 when scale is 0.5 (effective size 20)',
+      reason:
+          'Should erase stroke at distance 15 when scale is 0.5 (effective size 20)',
     );
   });
 }

--- a/test/tools_eraser_test.dart
+++ b/test/tools_eraser_test.dart
@@ -56,6 +56,7 @@ void main() {
     final List<Stroke> erased = eraser.checkForOverlappingStrokes(
       _eraserPos,
       strokes,
+      scale: 1.0
     );
 
     for (final stroke in strokesToErase) {
@@ -95,13 +96,13 @@ void main() {
       _eraserPos + const Offset(1, 0) * eraser.size,
     );
 
-    // Check with scale 1.0 (default)
+    // Check with scale 1.0
     var erased = eraser.checkForOverlappingStrokes(_eraserPos, [
       strokeAtEdge,
     ], scale: 1.0);
     expect(
-      erased.contains(strokeAtEdge),
-      true,
+      erased,
+      contains(strokeAtEdge),
       reason: 'Should erase stroke at edge with scale 1.0',
     );
 
@@ -125,8 +126,8 @@ void main() {
       strokeFurtherAway,
     ], scale: 0.5);
     expect(
-      erased.contains(strokeFurtherAway),
-      true,
+      erased,
+      contains(strokeFurtherAway),
       reason:
           'Should erase stroke at distance 15 when scale is 0.5 (effective size 20)',
     );

--- a/test/tools_eraser_test.dart
+++ b/test/tools_eraser_test.dart
@@ -86,6 +86,55 @@ void main() {
       reason: 'The correct strokes should have been erased',
     );
   });
+
+  test('Test that eraser size scales inversely with zoom', () {
+    final eraser = Eraser(size: 10);
+    // At scale 1.0, this stroke is at the edge (distance = size)
+    // At scale 2.0, the effective size should be 5, so this stroke (at 10) should NOT be erased
+    final strokeAtEdge = _strokeWithPoint(
+      _eraserPos + const Offset(1, 0) * eraser.size,
+    );
+
+    // Check with scale 1.0 (default)
+    var erased = eraser.checkForOverlappingStrokes(
+      _eraserPos,
+      [strokeAtEdge],
+      scale: 1.0,
+    );
+    expect(
+      erased.contains(strokeAtEdge),
+      true,
+      reason: 'Should erase stroke at edge with scale 1.0',
+    );
+
+    // Check with scale 2.0 (eraser should be smaller in document coordinates)
+    erased = eraser.checkForOverlappingStrokes(
+      _eraserPos,
+      [strokeAtEdge],
+      scale: 2.0,
+    );
+    expect(
+      erased.contains(strokeAtEdge),
+      false,
+      reason: 'Should NOT erase stroke at distance 10 when scale is 2.0 (effective size 5)',
+    );
+
+    // At scale 0.5, effective size should be 20.
+    // A stroke at distance 15 should be erased.
+    final strokeFurtherAway = _strokeWithPoint(
+      _eraserPos + const Offset(1.5, 0) * eraser.size,
+    );
+    erased = eraser.checkForOverlappingStrokes(
+      _eraserPos,
+      [strokeFurtherAway],
+      scale: 0.5,
+    );
+    expect(
+      erased.contains(strokeFurtherAway),
+      true,
+      reason: 'Should erase stroke at distance 15 when scale is 0.5 (effective size 20)',
+    );
+  });
 }
 
 Stroke _strokeWithPoint(Offset point) => Stroke(


### PR DESCRIPTION
Addresses one open issue, and the second I felt more reasonable to have along with the first issue.
1) Closes the issue #1627 by scaling the eraser size to the display scale
2) Draws a small dotted-circle around the eraser tool when in use

Also, added the test for first part (thanks AI : ) for writing the testcase)