### PR TITLE
fix(onyxsdk_pen): exclude mmkv for 16kb pages support

### DIFF
--- a/packages/onyxsdk_pen/android/build.gradle.kts
+++ b/packages/onyxsdk_pen/android/build.gradle.kts
@@ -52,7 +52,9 @@ android {
 
     dependencies {
         implementation("com.onyx.android.sdk:onyxsdk-device:1.3.4")
-        implementation("com.onyx.android.sdk:onyxsdk-pen:1.5.4")
+        implementation("com.onyx.android.sdk:onyxsdk-pen:1.5.4") {
+            exclude(group = "com.tencent", module = "mmkv")
+        }
         implementation("org.lsposed.hiddenapibypass:hiddenapibypass:6.1")
     }
 


### PR DESCRIPTION
**Testers needed**

If you have an Onyx device, please test the updated APK below. Let me know if everything is working as before, including various pen styles and the eraser. Note: You need to be logged in to GitHub before you can download it.

\>>> [Download testing APK](https://github.com/saber-notes/saber/actions/runs/26191744576/artifacts/7122489088) <<<

(Hopefully) closes https://github.com/saber-notes/saber/issues/1565