### PR TITLE
test: misc test speedups

### DIFF
--- a/lib/components/canvas/save_indicator.dart
+++ b/lib/components/canvas/save_indicator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:saber/components/theming/adaptive_circular_progress_indicator.dart';
+import 'package:saber/data/is_this_a_test.dart';
 import 'package:saber/data/routes.dart';
 
 /// Replaces the back button as the
@@ -22,7 +23,9 @@ class SaveIndicator extends StatelessWidget {
       valueListenable: savingState,
       builder: (context, isSaving, _) {
         return AnimatedSwitcher(
-          duration: const Duration(milliseconds: 300),
+          duration: isThisATest
+              ? Duration.zero
+              : const Duration(milliseconds: 300),
           child: IconButton(
             key: ValueKey(savingState.value),
             onPressed: () => _onPressed(context),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -587,10 +587,11 @@ packages:
   flutter_speed_dial:
     dependency: "direct main"
     description:
-      name: flutter_speed_dial
-      sha256: "698a037274a66dbae8697c265440e6acb6ab6cae9ac5f95c749e7944d8f28d41"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "fix/remove-Future.delayed"
+      resolved-ref: "272a4949ac52438969c7a73db575cfa551f88f66"
+      url: "https://github.com/adil192/flutter_speed_dial.git"
+    source: git
     version: "7.0.0"
   flutter_staggered_grid_view:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -182,6 +182,14 @@ dev_dependencies:
 
   sentry_dart_plugin: ^3.1.1
 
+dependency_overrides:
+  # https://github.com/darioielardi/flutter_speed_dial/pull/344
+  # Note: flutter_speed_dial hasn't been updated in 3 years, maybe replace it.
+  flutter_speed_dial:
+    git:
+      url: https://github.com/adil192/flutter_speed_dial.git
+      ref: fix/remove-Future.delayed
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/test/browse_navigation_test.dart
+++ b/test/browse_navigation_test.dart
@@ -27,32 +27,32 @@ void main() {
     });
     testWidgets('No back folder at root', (tester) async {
       await tester.pumpWidget(const _BrowseApp());
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(find.byIcon(Icons.arrow_back), findsNothing);
     });
     testWidgets('Back folder present in subfolder', (tester) async {
       await tester.pumpWidget(const _BrowseApp(path: '/helloworld'));
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(find.byIcon(Icons.arrow_back), findsOneWidget);
     });
     testWidgets('Navigate back to root', (tester) async {
       await tester.pumpWidget(const _BrowseApp(path: '/helloworld'));
-      await tester.pumpAndSettle();
+      await tester.pump();
       await tester.tap(find.byIcon(Icons.arrow_back));
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(find.byIcon(Icons.arrow_back), findsNothing);
     });
     testWidgets('Navigate back twice to root', (tester) async {
       await tester.pumpWidget(const _BrowseApp(path: '/helloworld'));
-      await tester.pumpAndSettle();
+      await tester.pump();
       await tester.tap(find.text('subfolder1'));
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(find.byIcon(Icons.arrow_back), findsOneWidget);
       await tester.tap(find.byIcon(Icons.arrow_back));
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(find.byIcon(Icons.arrow_back), findsOneWidget);
       await tester.tap(find.byIcon(Icons.arrow_back));
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(find.byIcon(Icons.arrow_back), findsNothing);
     });
   });

--- a/test/browse_page_test.dart
+++ b/test/browse_page_test.dart
@@ -67,11 +67,7 @@ class _BrowseApp extends StatelessWidget {
     return ScreenshotApp.withConditionalTitlebar(
       device: GoldenSmallDevices.androidPhone.device,
       title: 'Saber',
-      theme: SaberTheme.createThemeFromSeed(
-        Colors.yellow,
-        Brightness.light,
-        TargetPlatform.android,
-      ),
+      theme: SaberTheme.createThemeFromSeed(Colors.yellow, .light, .android),
       home: BrowsePage(path: path),
     );
   }

--- a/test/canvas_backgrounds_test.dart
+++ b/test/canvas_backgrounds_test.dart
@@ -21,9 +21,6 @@ void _testPatternWithLineHeight(
   test("'$pattern' with line height $lineHeight", () {
     const size = Size(1000, 1000);
 
-    /// We can't directly compare doubles, so check if they're within a small range (±epsilon)
-    final epsilon = lineHeight / 100;
-
     final elements = CanvasBackgroundPainter.getPatternElements(
       pattern: pattern,
       size: size,
@@ -32,15 +29,15 @@ void _testPatternWithLineHeight(
 
     if (pattern == .none) {
       expect(
-        elements.isEmpty,
-        true,
+        elements,
+        isEmpty,
         reason: 'No elements should be returned for the none pattern',
       );
       return;
     } else {
       expect(
-        elements.isEmpty,
-        false,
+        elements,
+        isNotEmpty,
         reason:
             'Elements should be returned for patterns other than the none pattern',
       );
@@ -50,22 +47,22 @@ void _testPatternWithLineHeight(
     for (final element in elements) {
       expect(
         element.start.dx,
-        lessThanOrEqualTo(size.width),
+        inInclusiveRange(0, size.width),
         reason: 'element.start not within canvas bounds',
       );
       expect(
         element.start.dy,
-        lessThanOrEqualTo(size.height),
+        inInclusiveRange(0, size.height),
         reason: 'element.start not within canvas bounds',
       );
       expect(
         element.end.dx,
-        lessThanOrEqualTo(size.width),
+        inInclusiveRange(0, size.width),
         reason: 'element.end not within canvas bounds',
       );
       expect(
         element.end.dy,
-        lessThanOrEqualTo(size.height),
+        inInclusiveRange(0, size.height),
         reason: 'element.end not within canvas bounds',
       );
     }
@@ -75,13 +72,13 @@ void _testPatternWithLineHeight(
       if (element.secondaryColor) return; // ignore secondary elements
       expect(
         element.start.dy,
-        greaterThan(lineHeight * 2 - 1),
+        greaterThanOrEqualTo(lineHeight * 2),
         reason:
             'Elements should leave 2 lineHeights of space at the top, but element.start.dy was ${element.start.dy}',
       );
       expect(
         element.end.dy,
-        greaterThan(lineHeight * 2 - 1),
+        greaterThanOrEqualTo(lineHeight * 2),
         reason:
             'Elements should leave 2 lineHeights of space at the top, but element.end.dy was ${element.end.dy}',
       );
@@ -138,7 +135,7 @@ void _testPatternWithLineHeight(
         );
         expect(
           diffFromALine,
-          lessThan(epsilon),
+          lessThan(lineHeight / 1000),
           reason: 'Lines should be spaced in intervals of lineHeight',
         );
 

--- a/test/canvas_transform_cache_test.dart
+++ b/test/canvas_transform_cache_test.dart
@@ -20,17 +20,15 @@ void main() {
 
     // add first item
     CanvasTransformCache.add(samples[0].filePath, samples[0].transform);
-    expect(CanvasTransformCache.get(samples[0].filePath), isNotNull);
     expect(
-      CanvasTransformCache.get(samples[0].filePath)!.transform,
+      CanvasTransformCache.get(samples[0].filePath)?.transform,
       samples[0].transform,
     );
 
     // update first item
     CanvasTransformCache.add(samples[0].filePath, samples[1].transform);
-    expect(CanvasTransformCache.get(samples[0].filePath), isNotNull);
     expect(
-      CanvasTransformCache.get(samples[0].filePath)!.transform,
+      CanvasTransformCache.get(samples[0].filePath)?.transform,
       samples[1].transform,
     );
 
@@ -44,9 +42,8 @@ void main() {
     expect(CanvasTransformCache.get(samples[0].filePath), isNull);
     // the rest of the items should be in the cache
     for (final sample in samples.skip(1)) {
-      expect(CanvasTransformCache.get(sample.filePath), isNotNull);
       expect(
-        CanvasTransformCache.get(sample.filePath)!.transform,
+        CanvasTransformCache.get(sample.filePath)?.transform,
         sample.transform,
       );
     }

--- a/test/cleanup_assets_test.dart
+++ b/test/cleanup_assets_test.dart
@@ -34,7 +34,10 @@ void main() {
         file.create(recursive: true),
     ]);
 
-    FileManager.removeUnusedAssets(sbnPath, numAssets: usedFiles.length - 1);
+    await FileManager.removeUnusedAssets(
+      sbnPath,
+      numAssets: usedFiles.length - 1,
+    );
 
     // check that used files are still there
     for (final file in usedFiles) {

--- a/test/editor_undo_redo_test.dart
+++ b/test/editor_undo_redo_test.dart
@@ -1,68 +1,39 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
 import 'package:golden_screenshot/golden_screenshot.dart';
-import 'package:saber/components/theming/dynamic_material_app.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/flavor_config.dart';
 import 'package:saber/i18n/strings.g.dart';
 import 'package:saber/pages/editor/editor.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'utils/test_mock_channel_handlers.dart';
 
 void main() {
   testGoldens('Editor: undo/redo buttons interaction test', (tester) async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    HttpOverrides.global = null; // needed for [google_fonts] package
 
     setupMockPathProvider();
     setupMockPrinting();
-    SharedPreferences.setMockInitialValues({});
 
     FlavorConfig.setup();
     await tester.runAsync(FileManager.init);
 
-    const filePath = '/tests/editor_undo_redo_test';
-    await tester.runAsync(() async {
-      await FileManager.deleteFile(filePath + Editor.extension);
-    });
-
-    final router = GoRouter(
-      routes: [
-        GoRoute(
-          path: '/',
-          builder: (context, state) => SizedBox(
-            width: 1000,
-            height: 1000,
-            child: Editor(path: filePath),
-          ),
-        ),
-      ],
-    );
     await tester.pumpWidget(
       TranslationProvider(
-        child: DynamicMaterialApp(title: 'Saber', router: router),
+        child: ScreenshotApp(
+          device: GoldenScreenshotDevices.androidPhone.device,
+          home: Editor(),
+        ),
       ),
     );
-    await tester.pumpAndSettle();
 
-    // wait for editor to load (i.e. when readOnly is false)
     final editorState = tester.state<EditorState>(find.byType(Editor));
-    for (var i = 0; i < 10; i++) {
-      if (!editorState.coreInfo.readOnly) break;
-      await tester.runAsync(
-        () => Future.delayed(const Duration(milliseconds: 10)),
-      );
-    }
     expect(
       editorState.coreInfo.readOnly,
       isFalse,
-      reason: 'Editor is still read-only',
+      reason: 'New file should not be read-only',
     );
-    printOnFailure('Editor core info is loaded');
+    addTearDown(editorState.cancelAutosaveAndMarkSaved);
 
     IconButton getUndoBtn() => tester.widget<IconButton>(
       find.ancestor(
@@ -78,81 +49,52 @@ void main() {
     );
 
     expect(
-      getUndoBtn().onPressed,
-      isNull,
-      reason: 'Undo button should be disabled initially',
-    );
-    expect(
-      getRedoBtn().onPressed,
-      isNull,
-      reason: 'Redo button should be disabled initially',
+      [getUndoBtn().onPressed, getRedoBtn().onPressed],
+      [isNull, isNull],
+      reason: 'Undo/redo buttons should be disabled initially',
     );
 
-    // draw something
     await drawOnEditor(tester);
-    await tester.pumpAndSettle();
+    await tester.pump();
+    expect(editorState.coreInfo.pages.first.strokes, hasLength(1));
     expect(
-      getUndoBtn().onPressed,
-      isNotNull,
+      [getUndoBtn().onPressed, getRedoBtn().onPressed],
+      [isNotNull, isNull],
       reason: 'Undo button should be enabled after first draw',
-    );
-    expect(
-      getRedoBtn().onPressed,
-      isNull,
-      reason: 'Redo button should be disabled after first draw',
     );
 
     // undo
     await tester.tap(find.byIcon(Icons.undo));
     await tester.pump();
+    expect(editorState.coreInfo.pages.first.strokes, hasLength(0));
     expect(
-      getUndoBtn().onPressed,
-      isNull,
+      [getUndoBtn().onPressed, getRedoBtn().onPressed],
+      [isNull, isNotNull],
       reason: 'Undo button should be disabled after undo',
-    );
-    expect(
-      getRedoBtn().onPressed,
-      isNotNull,
-      reason: 'Redo button should be enabled after undo',
     );
 
     // redo
     await tester.tap(find.byIcon(Icons.redo));
     await tester.pump();
+    expect(editorState.coreInfo.pages.first.strokes, hasLength(1));
     expect(
-      getUndoBtn().onPressed,
-      isNotNull,
+      [getUndoBtn().onPressed, getRedoBtn().onPressed],
+      [isNotNull, isNull],
       reason: 'Undo button should be enabled after redo',
-    );
-    expect(
-      getRedoBtn().onPressed,
-      isNull,
-      reason: 'Redo button should be disabled after redo',
     );
 
     // undo, then draw again
     await tester.tap(find.byIcon(Icons.undo));
     await tester.pump();
+    expect(editorState.coreInfo.pages.first.strokes, hasLength(0));
     await drawOnEditor(tester);
     await tester.pump();
+    expect(editorState.coreInfo.pages.first.strokes, hasLength(1));
     expect(
-      getUndoBtn().onPressed,
-      isNotNull,
+      [getUndoBtn().onPressed, getRedoBtn().onPressed],
+      [isNotNull, isNull],
       reason: 'Undo button should be enabled after undo and draw',
     );
-    expect(
-      getRedoBtn().onPressed,
-      isNull,
-      reason: 'Redo button should be disabled after undo and draw',
-    );
-
-    // save file now to supersede the save timer (which would run after the test is finished)
-    printOnFailure('Saving file: $filePath${Editor.extension}');
-    await tester.runAsync(() async {
-      await editorState.saveToFile();
-      await Future.delayed(const Duration(milliseconds: 100));
-      await FileManager.deleteFile(filePath + Editor.extension);
-    });
   });
 }
 

--- a/test/fm_write_stream_test.dart
+++ b/test/fm_write_stream_test.dart
@@ -18,11 +18,7 @@ void main() {
     setUp(() async {
       events.clear();
       await subscription?.cancel();
-      subscription = FileManager.fileWriteStream.stream.listen((
-        FileOperation event,
-      ) {
-        events.add(event);
-      });
+      subscription = FileManager.fileWriteStream.stream.listen(events.add);
     });
     tearDown(() async {
       await subscription?.cancel();
@@ -33,7 +29,7 @@ void main() {
       FileManager.broadcastFileWrite(FileOperationType.write, '/test.sbn2');
 
       // wait for the event to be broadcast
-      await Future.delayed(const Duration(milliseconds: 100));
+      await null;
 
       // check that the event was received
       expect(events.length, 1);
@@ -54,16 +50,16 @@ void main() {
       // write to file
       await file.create(recursive: true);
       await file.writeAsString('test_content');
-      await Future.delayed(const Duration(milliseconds: 100));
-      expect(events.length, greaterThanOrEqualTo(2));
+      await Future.delayed(const Duration(milliseconds: 1));
+      expect(events, hasLength(greaterThanOrEqualTo(2)));
       expect(events.last.filePath, '/test'); // without the extension
       expect(events.last.type, FileOperationType.write);
       events.clear();
 
       // delete file
       await file.delete();
-      await Future.delayed(const Duration(milliseconds: 100));
-      expect(events.length, greaterThanOrEqualTo(1));
+      await Future.delayed(const Duration(milliseconds: 1));
+      expect(events, hasLength(greaterThanOrEqualTo(1)));
       expect(events.last.filePath, '/test'); // without the extension
       expect(events.last.type, FileOperationType.delete);
     });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed time-based waits to make tests faster and deterministic, and made the save indicator instant in tests. Simplified the editor undo/redo test and pinned `flutter_speed_dial` to remove internal delays.

- **Refactors**
  - fm_write_stream_test: replace long waits with microtask/1ms, use `stream.listen(events.add)`, tighten length matchers.
  - browse_navigation_test: replace `pumpAndSettle` with `pump`.
  - editor_undo_redo_test: use `ScreenshotApp` with `Editor`, drop file I/O and overrides, assert stroke counts and button states, add teardown to cancel autosave.
  - save_indicator: use `isThisATest` to set `AnimatedSwitcher` duration to zero during tests.

- **Dependencies**
  - Override `flutter_speed_dial` to `https://github.com/adil192/flutter_speed_dial.git#fix/remove-Future.delayed` to eliminate `Future.delayed` usage.

Note: Saber is trialling Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit c949d14ebdcfb339e72cded73aa46ce6ef833bab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

