### PR TITLE
l10n(cs): Add fallback info to README

### DIFF
--- a/README-cs.md
+++ b/README-cs.md
@@ -95,6 +95,8 @@ Pokud byste chtěli pomoci s překladem aplikace Saber, přejděte na [Weblate](
 
 [![Stav překladů](https://hosted.weblate.org/widget/saber-notes/multi-auto.svg)](https://hosted.weblate.org/engage/saber-notes/)
 
+Poznámka: Abychom předešli nutnosti vyplňovat mezery v překladech angličtinou, jsou chybějící překlady podchyceny strojovým překladem, a to do doby, než se k překladu dostane lidský přispěvovatel.
+
 ## Podpora aplikace Saber
 
 Pokud máte rádi Saber, zvažte prosím jeho podporu pomocí


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a note to the Czech README that missing strings are temporarily machine-translated instead of falling back to English, until a human translation is provided. This clarifies the localization fallback behavior for Czech users and contributors.

Note: Saber is trialling Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit be0cc0726aa50beaf9040c8257be5174d0190117. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

