### PR TITLE
perf: avoid png encode where immediately decoded

### DIFF
--- a/lib/data/editor/editor_exporter.dart
+++ b/lib/data/editor/editor_exporter.dart
@@ -1,7 +1,8 @@
-import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:image/image.dart' as im;
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:saber/components/canvas/_circle_stroke.dart';
@@ -36,18 +37,30 @@ abstract class EditorExporter {
     }
 
     final pdf = pw.Document();
-    final screenshotController = ScreenshotController();
 
     // screenshot each page
     final pageScreenshots = await Future.wait(
-      List.generate(
-        coreInfo.pages.length,
-        (pageIndex) => screenshotPage(
+      List.generate(coreInfo.pages.length, (pageIndex) async {
+        final uiImage = await screenshotPage(
           coreInfo: coreInfo,
           pageIndex: pageIndex,
-          screenshotController: screenshotController,
-        ),
-      ),
+        );
+        final byteData = await uiImage.toByteData(
+          format: ui.ImageByteFormat.rawRgba,
+        );
+        assert(
+          byteData != null,
+          'Judging by the code, this should never be null.',
+        );
+        final imImage = im.Image.fromBytes(
+          width: uiImage.width,
+          height: uiImage.height,
+          bytes: byteData!.buffer,
+          order: im.ChannelOrder.rgba,
+        );
+        uiImage.dispose();
+        return imImage;
+      }),
     );
 
     for (int pageIndex = 0; pageIndex < pageScreenshots.length; ++pageIndex) {
@@ -115,7 +128,7 @@ abstract class EditorExporter {
                   }
                 },
                 child: pw.Image(
-                  pw.MemoryImage(pageScreenshots[pageIndex]),
+                  pw.ImageImage(pageScreenshots[pageIndex]),
                   width: pageSize.width,
                   height: pageSize.height,
                 ),
@@ -135,10 +148,11 @@ abstract class EditorExporter {
   /// because they're added separately to the PDF as vector graphics.
   /// See [shouldRasterizeStroke] for more details, or set
   /// [rasterizeAllStrokes] to true to include all strokes in the screenshot.
-  static Future<Uint8List> screenshotPage({
+  ///
+  /// You must dispose this image when you're done.
+  static Future<ui.Image> screenshotPage({
     required EditorCoreInfo coreInfo,
     required int pageIndex,
-    required ScreenshotController screenshotController,
     bool rasterizeAllStrokes = false,
     Size? targetSize,
     double? cropHeight,
@@ -155,7 +169,7 @@ abstract class EditorExporter {
             if (i == pageIndex) page else coreInfo.pages[i],
         ],
       );
-      return await screenshotController.captureFromWidget(
+      return await ScreenshotController.widgetToUiImage(
         EditorExporterTheme(
           targetSize: targetSize,
           child: CanvasPreview(

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -50,7 +50,6 @@ import 'package:saber/data/tools/shape_pen.dart';
 import 'package:saber/i18n/strings.g.dart';
 import 'package:saber/pages/home/whiteboard.dart';
 import 'package:sbn/change.dart';
-import 'package:screenshot/screenshot.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 
 typedef _PhotoInfo = ({Uint8List bytes, String extension});
@@ -975,16 +974,17 @@ class EditorState extends State<Editor> {
     final thumbnail = await EditorExporter.screenshotPage(
       coreInfo: coreInfo,
       pageIndex: 0,
-      screenshotController: ScreenshotController(),
       rasterizeAllStrokes: true,
       targetSize: thumbnailSize,
       cropHeight: previewHeight,
       pixelRatio: 1,
     );
+    final thumbnailPng = await thumbnail.toByteData(format: .png);
+    thumbnail.dispose();
     await FileManager.writeFile(
       // Note that this ends with .sbn2.p
       '$filePath.p',
-      thumbnail,
+      thumbnailPng!.buffer.asUint8List(),
       awaitWrite: true,
     );
   }
@@ -1338,18 +1338,19 @@ class EditorState extends State<Editor> {
     if (targetPixelRatio > 1) targetPixelRatio = 1;
 
     try {
-      final Uint8List pngBytes = await EditorExporter.screenshotPage(
+      final image = await EditorExporter.screenshotPage(
         coreInfo: coreInfo,
         pageIndex: currentPageIndex,
-        screenshotController: ScreenshotController(),
         rasterizeAllStrokes: true,
         pixelRatio: targetPixelRatio,
       );
+      final pngBytes = await image.toByteData(format: .png);
+      image.dispose();
 
       if (!context.mounted) return;
       await FileManager.exportFile(
         '${coreInfo.fileName}_page_${currentPageIndex + 1}.png',
-        pngBytes,
+        pngBytes!.buffer.asUint8List(),
         isImage: true,
         context: context,
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -737,7 +737,7 @@ packages:
     source: hosted
     version: "3.1.0"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -159,6 +159,7 @@ dependencies:
 
   flutter_hooks: ^0.21.3+1
   dynamic_yaru: ^0.1.0
+  image: ^4.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Avoid PNG encode/decode during export by capturing pages as `ui.Image` and feeding raw RGBA into the PDF pipeline. Exports run faster and use less memory; PNG encoding now only happens when writing image files.

- **Performance**
  - Capture pages as `ui.Image`, convert to `im.Image`, and use `pw.ImageImage` to avoid PDF-side PNG decode.
  - Encode to PNG only for final file outputs (thumbnails and PNG export).
  - Dispose `ui.Image` after use to free memory.

- **Migration**
  - `EditorExporter.screenshotPage` now returns `ui.Image` instead of PNG bytes. Call `toByteData(...)` when you need bytes and dispose the image when done.

Note: Saber is trialling Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 2bb09b6ec4f063294046adc6836978e96fd52a9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

