### PR TITLE
feat: added custom window shell

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "be698c48a6750c8cb8e61c740ca9991bb947aba2"
+  revision: "924134a44c189315be2148659913dda1671cbe99"
   channel: "stable"
 
 project_type: app
@@ -13,23 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-    - platform: android
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-    - platform: ios
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-    - platform: linux
-      create_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-      base_revision: adc901062556672b4138e18a4dc62a4be8f4b3c2
-    - platform: macos
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      create_revision: 924134a44c189315be2148659913dda1671cbe99
+      base_revision: 924134a44c189315be2148659913dda1671cbe99
     - platform: windows
-      create_revision: e1e47221e86272429674bec4f1bd36acc4fc7b77
-      base_revision: e1e47221e86272429674bec4f1bd36acc4fc7b77
+      create_revision: 924134a44c189315be2148659913dda1671cbe99
+      base_revision: 924134a44c189315be2148659913dda1671cbe99
 
   # User provided section
 

--- a/lib/components/desktop/window_shell.dart
+++ b/lib/components/desktop/window_shell.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class DesktopWindowShell extends StatelessWidget {
+  final Widget child;
+  final BuildContext? context;
+
+  const DesktopWindowShell({required this.child, this.context, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDesktop =
+        Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+
+    if (!isDesktop) {
+      return child;
+    }
+
+    return Column(
+      children: [
+        _WindowTitleBar(context: context),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+class _WindowTitleBar extends StatelessWidget {
+  final BuildContext context;
+
+  const _WindowTitleBar({required this.context});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(this.context);
+    final backgroundColor = switch (theme.platform) {
+      .linux => Colors.transparent,
+      _ => theme.colorScheme.surfaceContainer,
+    };
+    final iconColor = Theme.of(context).colorScheme.onSurface;
+
+    return Container(
+      height: 32,
+      color: backgroundColor,
+      child: Row(
+        children: [
+          Expanded(
+            child: MoveWindow(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Row(
+                    children: [
+                      SvgPicture.asset(
+                        'assets/icon/icon.svg',
+                        height: 12,
+                        width: 12,
+                        fit: BoxFit.contain,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Saber',
+                        style: TextStyle(
+                          color: iconColor,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w500,
+                          decoration: TextDecoration.none,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          _WindowButtons(iconColor: iconColor),
+        ],
+      ),
+    );
+  }
+}
+
+class _WindowButtons extends StatelessWidget {
+  final Color iconColor;
+
+  const _WindowButtons({required this.iconColor});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        MinimizeWindowButton(
+          colors: _buttonColors(iconColor),
+          onPressed: () => appWindow.minimize(),
+        ),
+        MaximizeWindowButton(
+          colors: _buttonColors(iconColor),
+          onPressed: () => appWindow.maximize(),
+        ),
+        CloseWindowButton(
+          colors: _buttonColors(iconColor, closeButton: true),
+          onPressed: () => appWindow.close(),
+        ),
+      ],
+    );
+  }
+
+  WindowButtonColors _buttonColors(
+    Color iconColor, {
+    bool closeButton = false,
+  }) {
+    return WindowButtonColors(
+      iconNormal: iconColor,
+      iconMouseOver: iconColor,
+      iconMouseDown: iconColor,
+      normal: Colors.transparent,
+      mouseOver: Colors.grey.withValues(alpha: 0.2),
+      mouseDown: closeButton
+          ? Colors.red.withValues(alpha: 0.8)
+          : Colors.grey.withValues(alpha: 0.6),
+    );
+  }
+}

--- a/lib/components/theming/dynamic_material_app.dart
+++ b/lib/components/theming/dynamic_material_app.dart
@@ -14,6 +14,7 @@ import 'package:saber/data/prefs.dart';
 import 'package:saber/i18n/extensions/redirecting_localization_delegate.dart';
 import 'package:saber/i18n/strings.g.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:saber/components/desktop/window_shell.dart';
 
 class DynamicMaterialApp extends StatefulHookWidget {
   const DynamicMaterialApp({
@@ -91,6 +92,14 @@ class DynamicMaterialAppState extends State<DynamicMaterialApp>
       chosenAccentColor = null; // discard transparent accent color
     useListenable(stows.hyperlegibleFont);
 
+    // Helper to build the app with optional desktop window shell
+    TransitionBuilder? _buildWithDesktopShell(TransitionBuilder? builder) {
+      if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+        return (context, child) => DesktopWindowShell(child: child!);
+      }
+      return builder;
+    }
+
     // Use Yaru theme, with or without [chosenAccentColor]
     if (platform == .linux) {
       return YaruBuilder(
@@ -105,6 +114,7 @@ class DynamicMaterialAppState extends State<DynamicMaterialApp>
             darkTheme: themes.darkTheme,
             highContrastTheme: themes.highContrastTheme,
             highContrastDarkTheme: themes.highContrastDarkTheme,
+            builder: _buildWithDesktopShell(null),
           );
         },
       );
@@ -126,6 +136,7 @@ class DynamicMaterialAppState extends State<DynamicMaterialApp>
           .dark,
           platform,
         ),
+        builder: _buildWithDesktopShell(null),
       );
     }
 
@@ -150,6 +161,7 @@ class DynamicMaterialAppState extends State<DynamicMaterialApp>
                   .dark,
                   platform,
                 ),
+          builder: _buildWithDesktopShell(null),
         );
       },
     );
@@ -176,6 +188,7 @@ class ExplicitlyThemedApp extends StatelessWidget {
     required this.darkTheme,
     this.highContrastTheme,
     this.highContrastDarkTheme,
+    this.builder,
   });
 
   final String title;
@@ -183,6 +196,7 @@ class ExplicitlyThemedApp extends StatelessWidget {
   final ThemeMode themeMode;
   final ThemeData theme;
   final ThemeData? darkTheme, highContrastTheme, highContrastDarkTheme;
+  final TransitionBuilder? builder;
 
   static final _materialAppKey = GlobalKey<State<MaterialApp>>();
 
@@ -225,6 +239,7 @@ class ExplicitlyThemedApp extends StatelessWidget {
       highContrastTheme: highContrastTheme,
       highContrastDarkTheme: highContrastDarkTheme,
       debugShowCheckedModeBanner: false,
+      builder: builder,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,12 +47,13 @@ Future<void> main(List<String> args) async {
 Future<void> appRunner(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  doWhenWindowReady(() {
-    const initialSize = Size(600, 450);
-    appWindow.minSize = initialSize;
-    appWindow.alignment = Alignment.center;
-    appWindow.show(); // This is crucial!
-  });
++  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS)
++    doWhenWindowReady(() {
++      const initialSize = Size(600, 450);
++      appWindow.minSize = initialSize;
++      appWindow.alignment = Alignment.center;
++      appWindow.show(); // This is crucial!
++    });
 
   final parser = ArgParser()..addFlag('verbose', abbr: 'v', negatable: false);
   final parsedArgs = parser.parse(args);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:io';
-
+import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:args/args.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -46,6 +46,13 @@ Future<void> main(List<String> args) async {
 
 Future<void> appRunner(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  doWhenWindowReady(() {
+    const initialSize = Size(600, 450);
+    appWindow.minSize = initialSize;
+    appWindow.alignment = Alignment.center;
+    appWindow.show(); // This is crucial!
+  });
 
   final parser = ArgParser()..addFlag('verbose', abbr: 'v', negatable: false);
   final parsedArgs = parser.parse(args);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,13 +47,13 @@ Future<void> main(List<String> args) async {
 Future<void> appRunner(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
 
-+  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS)
-+    doWhenWindowReady(() {
-+      const initialSize = Size(600, 450);
-+      appWindow.minSize = initialSize;
-+      appWindow.alignment = Alignment.center;
-+      appWindow.show(); // This is crucial!
-+    });
+  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS)
+    doWhenWindowReady(() {
+      const initialSize = Size(600, 450);
+      appWindow.minSize = initialSize;
+      appWindow.alignment = Alignment.center;
+      appWindow.show(); // This is crucial!
+    });
 
   final parser = ArgParser()..addFlag('verbose', abbr: 'v', negatable: false);
   final parsedArgs = parser.parse(args);

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
@@ -23,6 +24,9 @@
 #include <yaru_window_linux/yaru_window_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) bitsdojo_window_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "BitsdojoWindowPlugin");
+  bitsdojo_window_plugin_register_with_registrar(bitsdojo_window_linux_registrar);
   g_autoptr(FlPluginRegistrar) desktop_webview_window_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWebviewWindowPlugin");
   desktop_webview_window_plugin_register_with_registrar(desktop_webview_window_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  bitsdojo_window_linux
   desktop_webview_window
   dynamic_color
   file_selector_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import bitsdojo_window_macos
 import desktop_webview_window
 import device_info_plus
 import dynamic_color
@@ -26,6 +27,7 @@ import window_manager
 import window_to_front
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  BitsdojoWindowPlugin.register(with: registry.registrar(forPlugin: "BitsdojoWindowPlugin"))
   DesktopWebviewWindowPlugin.register(with: registry.registrar(forPlugin: "DesktopWebviewWindowPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.13"
+  bitsdojo_window:
+    dependency: "direct main"
+    description:
+      name: bitsdojo_window
+      sha256: "88ef7765dafe52d97d7a3684960fb5d003e3151e662c18645c1641c22b873195"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
+  bitsdojo_window_linux:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_linux
+      sha256: "9519c0614f98be733e0b1b7cb15b827007886f6fe36a4fb62cf3d35b9dd578ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
+  bitsdojo_window_macos:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_macos
+      sha256: f7c5be82e74568c68c5b8449e2c5d8fd12ec195ecd70745a7b9c0f802bb0268f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
+  bitsdojo_window_platform_interface:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_platform_interface
+      sha256: "65daa015a0c6dba749bdd35a0f092e7a8ba8b0766aa0480eb3ef808086f6e27c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
+  bitsdojo_window_windows:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_windows
+      sha256: fa982cf61ede53f483e50b257344a1c250af231a3cdc93a7064dd6dc0d720b68
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   boolean_selector:
     dependency: transitive
     description:
@@ -245,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.14"
   decimal:
     dependency: transitive
     description:
@@ -508,10 +548,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.34"
+    version: "2.0.35"
   flutter_quill:
     dependency: "direct main"
     description:
@@ -668,10 +708,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f"
+      sha256: "5922b2861e2235a3504896f0d6fa07d84141b480cf52eecd2f42cd25585a9e8a"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.3"
+    version: "17.3.0"
   golden_screenshot:
     dependency: "direct dev"
     description:
@@ -1607,10 +1647,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      sha256: a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.23"
+    version: "2.4.25"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1764,10 +1804,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0+1"
+    version: "3.4.1"
   system_info2:
     dependency: transitive
     description:
@@ -1836,10 +1876,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.30"
+    version: "6.3.32"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1996,10 +2036,10 @@ packages:
     dependency: transitive
     description:
       name: window_to_front
-      sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
+      sha256: "14fad8984db4415e2eeb30b04bb77140b180e260d6cb66b26de126a8657a9241"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.3"
+    version: "0.0.4"
   worker_manager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -160,6 +160,8 @@ dependencies:
   flutter_hooks: ^0.21.3+1
   dynamic_yaru: ^0.1.0
 
+  bitsdojo_window: ^0.1.6
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/browse_navigation_test.dart
+++ b/test/browse_navigation_test.dart
@@ -87,6 +87,7 @@ class _BrowseApp extends StatelessWidget {
         themeMode: ThemeMode.light,
         theme: theme,
         darkTheme: theme,
+        builder: null,
       ),
     );
   }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
@@ -22,6 +23,8 @@
 #include <window_to_front/window_to_front_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  BitsdojoWindowPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
   DesktopWebviewWindowPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopWebviewWindowPlugin"));
   DynamicColorPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  bitsdojo_window_windows
   desktop_webview_window
   dynamic_color
   file_selector_windows

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -5,6 +5,9 @@
 #include "flutter_window.h"
 #include "utils.h"
 
+#include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
+auto bdw = bitsdojo_window_configure(BDW_CUSTOM_FRAME);
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
   // Attach to console when present (e.g., 'flutter run') or create a


### PR DESCRIPTION
Introduced colored buttons based on theme for consistency in desktop

Before:
<img width="1623" height="923" alt="image" src="https://github.com/user-attachments/assets/bf7663c1-5aa2-4935-bf91-1811d527fb5f" />

After:
<img width="1630" height="932" alt="image" src="https://github.com/user-attachments/assets/b0fb3e8e-00f4-40e1-84ad-56c7e202c338" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a custom desktop window shell with a themed title bar and native-like window controls on Windows, macOS, and Linux. The shell only applies on desktop; mobile builds are unchanged.

- **New Features**
  - Added `DesktopWindowShell` with a draggable title bar, app icon/title, and minimize/maximize/close buttons using theme colors.
  - Linux uses a transparent title bar for a native look.
  - Applied via `MaterialApp` builder with a desktop platform guard.
  - Set desktop min size (600x450), centered the window, and showed it on launch.
  - Enabled custom frame on Windows via `BDW_CUSTOM_FRAME`.

- **Dependencies**
  - Added `bitsdojo_window` and platform plugins (`bitsdojo_window_linux`, `bitsdojo_window_macos`, `bitsdojo_window_windows`).
  - Updated plugin registrants and build files for Linux, macOS, and Windows.

Note: Saber is trialling Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 3122e1dbd5e6c8de368261c05563239634135a98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

