### PR TITLE
tweak: smoother scrolling fling gesture

### DIFF
--- a/lib/components/canvas/canvas_gesture_detector.dart
+++ b/lib/components/canvas/canvas_gesture_detector.dart
@@ -506,8 +506,8 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
                   panEnabled: !singleFingerPanLock,
                   panAxis: axisAlignedPanLock ? PanAxis.aligned : PanAxis.free,
 
-                  interactionEndFrictionCoefficient:
-                      InteractiveCanvasViewer.kDrag * 100,
+                  // Smoother scrolling fling gesture than the default
+                  interactionEndFrictionCoefficient: 0.3,
 
                   // we need a non-zero boundary margin so we can zoom out
                   // past the size of the page (for minScale < 1)

--- a/lib/components/canvas/interactive_canvas.dart
+++ b/lib/components/canvas/interactive_canvas.dart
@@ -1,7 +1,8 @@
-// Adapted for Saber from Flutter's InteractiveViewer class
-// https://github.com/flutter/flutter/blob/stable/packages/flutter/lib/src/widgets/interactive_viewer.dart
-// Using this commit (Flutter 3.35.0):
-// https://github.com/flutter/flutter/blob/1cbf1a4cbf2cd0ba73850e47f4a83dd06a049e82/packages/flutter/lib/src/widgets/interactive_viewer.dart
+/// Adapted for Saber from Flutter's [InteractiveViewer] class
+/// https://github.com/flutter/flutter/blob/stable/packages/flutter/lib/src/widgets/interactive_viewer.dart
+/// Using this commit (Flutter 3.44.0):
+/// https://github.com/flutter/flutter/blob/86b97230b17c2fd37cf9e615f1f32650e1541d75/packages/flutter/lib/src/widgets/interactive_viewer.dart
+library;
 
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
Makes scrolling smoother especially on mobile, and goes a long way to make the editor feel faster.

It's still not as smooth as Google Photos (i.e. fling doesn't ease-out but stops abruptly): I think we're limited by Flutter's `FrictionSimulation`.

Tested on my Android phone (touchscreen) and Linux laptop (trackpad).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths the canvas fling gesture by lowering the end-of-interaction friction to 0.3, improving scroll feel on touch and trackpads. Also updates the InteractiveViewer adaptation header to Flutter 3.44.0 and adds a Dart library directive.

Note: Saber is trialling Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 58993209a2a867839e79a3efdede1a5c6a030826. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

