### PR TITLE
fix: blank pages in exports since v1.34.2

### DIFF
--- a/lib/components/canvas/image/editor_image.dart
+++ b/lib/components/canvas/image/editor_image.dart
@@ -194,6 +194,8 @@ sealed class EditorImage extends ChangeNotifier {
   @mustBeOverridden
   @mustCallSuper
   Future<void> loadIn() async {
+    if (_shouldLoadOut?.isCompleted == false) _shouldLoadOut?.complete(false);
+
     if (_firstLoadCompleter == null) {
       _firstLoadCompleter = Completer();
       firstLoad().then(
@@ -205,7 +207,6 @@ sealed class EditorImage extends ChangeNotifier {
     }
 
     _loadedIn = true;
-    if (_shouldLoadOut?.isCompleted == false) _shouldLoadOut?.complete(false);
   }
 
   /// Free up resources when the image is no longer visible.

--- a/lib/components/canvas/image/editor_image.dart
+++ b/lib/components/canvas/image/editor_image.dart
@@ -174,7 +174,7 @@ sealed class EditorImage extends ChangeNotifier {
   @visibleForTesting
   static var shouldLoadOutImmediately = false;
 
-  Completer? _firstLoadStatus;
+  Completer? _firstLoadCompleter;
   Completer<bool>? _shouldLoadOut;
   var _loadedIn = false;
   bool get loadedIn => _loadedIn;
@@ -194,9 +194,14 @@ sealed class EditorImage extends ChangeNotifier {
   @mustBeOverridden
   @mustCallSuper
   Future<void> loadIn() async {
-    _firstLoadStatus ??= Completer()..complete(firstLoad());
-    if (!_firstLoadStatus!.isCompleted) {
-      await _firstLoadStatus!.future;
+    if (_firstLoadCompleter == null) {
+      _firstLoadCompleter = Completer();
+      firstLoad().then(
+        _firstLoadCompleter!.complete,
+        onError: _firstLoadCompleter!.completeError,
+      );
+    } else if (!_firstLoadCompleter!.isCompleted) {
+      await _firstLoadCompleter!.future;
     }
 
     _loadedIn = true;

--- a/lib/data/editor/editor_exporter.dart
+++ b/lib/data/editor/editor_exporter.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -161,13 +162,17 @@ abstract class EditorExporter {
     final page = coreInfo.pages[pageIndex].cloneForRasterization(
       rasterizeAllStrokes: rasterizeAllStrokes,
     );
+
+    final imagesToLoad = [
+      ?page.backgroundImage,
+      ...page.images,
+    ].where((image) => !image.loadedIn).toList(growable: false);
+    await Future.wait(imagesToLoad.map((image) => image.loadIn()));
+
     try {
       targetSize ??= page.size;
       coreInfo = coreInfo.copyWith(
-        pages: [
-          for (var i = 0; i < coreInfo.pages.length; ++i)
-            if (i == pageIndex) page else coreInfo.pages[i],
-        ],
+        pages: [for (var i = 0; i < coreInfo.pages.length; ++i) page],
       );
       return await ScreenshotController.widgetToUiImage(
         EditorExporterTheme(
@@ -183,6 +188,7 @@ abstract class EditorExporter {
         delay: isThisATest ? .zero : const Duration(milliseconds: 50),
       );
     } finally {
+      for (final image in imagesToLoad) unawaited(image.loadOut());
       page.disposeClonedData();
     }
   }

--- a/lib/data/editor/editor_exporter.dart
+++ b/lib/data/editor/editor_exporter.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:image/image.dart' as im;
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
+import 'package:pool/pool.dart';
 import 'package:saber/components/canvas/_circle_stroke.dart';
 import 'package:saber/components/canvas/_rectangle_stroke.dart';
 import 'package:saber/components/canvas/_stroke.dart';
@@ -40,28 +42,32 @@ abstract class EditorExporter {
     final pdf = pw.Document();
 
     // screenshot each page
+    final pool = Pool((Platform.numberOfProcessors ~/ 2).clamp(1, 4));
     final pageScreenshots = await Future.wait(
-      List.generate(coreInfo.pages.length, (pageIndex) async {
-        final uiImage = await screenshotPage(
-          coreInfo: coreInfo,
-          pageIndex: pageIndex,
-        );
-        final byteData = await uiImage.toByteData(
-          format: ui.ImageByteFormat.rawRgba,
-        );
-        assert(
-          byteData != null,
-          'Judging by the code, this should never be null.',
-        );
-        final imImage = im.Image.fromBytes(
-          width: uiImage.width,
-          height: uiImage.height,
-          bytes: byteData!.buffer,
-          order: im.ChannelOrder.rgba,
-        );
-        uiImage.dispose();
-        return imImage;
-      }),
+      List.generate(
+        coreInfo.pages.length,
+        (pageIndex) => pool.withResource(() async {
+          final uiImage = await screenshotPage(
+            coreInfo: coreInfo,
+            pageIndex: pageIndex,
+          );
+          final byteData = await uiImage.toByteData(
+            format: ui.ImageByteFormat.rawRgba,
+          );
+          assert(
+            byteData != null,
+            'Judging by the code, this should never be null.',
+          );
+          final imImage = im.Image.fromBytes(
+            width: uiImage.width,
+            height: uiImage.height,
+            bytes: byteData!.buffer,
+            order: im.ChannelOrder.rgba,
+          );
+          uiImage.dispose();
+          return imImage;
+        }),
+      ),
     );
 
     for (int pageIndex = 0; pageIndex < pageScreenshots.length; ++pageIndex) {
@@ -185,7 +191,7 @@ abstract class EditorExporter {
         ),
         pixelRatio: pixelRatio,
         targetSize: targetSize,
-        delay: isThisATest ? .zero : const Duration(milliseconds: 50),
+        delay: isThisATest ? .zero : const Duration(milliseconds: 200),
       );
     } finally {
       for (final image in imagesToLoad) unawaited(image.loadOut());

--- a/lib/data/editor/editor_exporter.dart
+++ b/lib/data/editor/editor_exporter.dart
@@ -173,7 +173,9 @@ abstract class EditorExporter {
       ?page.backgroundImage,
       ...page.images,
     ].where((image) => !image.loadedIn).toList(growable: false);
-    await Future.wait(imagesToLoad.map((image) => image.loadIn()));
+    await Future.wait(
+      imagesToLoad.map((image) => image.loadIn()),
+    ).timeout(const Duration(seconds: 10), onTimeout: () => const []);
 
     try {
       targetSize ??= page.size;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1300,6 +1300,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.9.1"
+  pool:
+    dependency: "direct main"
+    description:
+      name: pool
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
   posix:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -160,6 +160,7 @@ dependencies:
   flutter_hooks: ^0.21.3+1
   dynamic_yaru: ^0.1.0
   image: ^4.8.0
+  pool: ^1.5.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes https://github.com/saber-notes/saber/issues/1769

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank pages in exports since v1.34.2 (fixes #1769) by preloading images with a timeout, hardening first-load sync, and throttling screenshot concurrency. Exports now render all pages, avoid hangs, and use less CPU.

- **Bug Fixes**
  - Preload background and embedded images before capture with a 10s timeout to prevent missing assets and hangs.
  - Stabilize first image load with a dedicated `Completer` (propagates errors, avoids false isCompleted); cancel pending loadOut sooner; unload images after capture.
  - Throttle screenshot concurrency using `pool` to 1–4 workers (based on cores/2) and increase stabilization delay to 200ms.

- **Dependencies**
  - Add `pool` v1.5.2 for controlled parallelism.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 65c18c3c4c42fd76bd84c707769d4fd984f861ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

