### PR TITLE
i18n: Update Italian

### DIFF
--- a/lib/i18n/_missing_translations.yaml
+++ b/lib/i18n/_missing_translations.yaml
@@ -624,15 +624,15 @@ hu:
 it:
   home:
     sort:
-      sortBy(OUTDATED): Sort by
-      nameAToZ(OUTDATED): Name (A-Z)
-      nameZToA(OUTDATED): Name (Z-A)
-      lastModifiedNewToOld(OUTDATED): Edited (Newest first)
-      lastModifiedOldToNew(OUTDATED): Edited (Oldest first)
+      sortBy(OUTDATED): Ordina per
+      nameAToZ(OUTDATED): Nome (A-Z)
+      nameZToA(OUTDATED): Nome (Z-A)
+      lastModifiedNewToOld(OUTDATED): Modificato (Dal più recente)
+      lastModifiedOldToNew(OUTDATED): Modificato (Dal più vecchio)
     layout:
       layout(OUTDATED): Layout
-      masonryGrid(OUTDATED): Masonry grid
-      simpleGrid(OUTDATED): Simple grid
+      masonryGrid(OUTDATED): Griglia a mosaico
+      simpleGrid(OUTDATED): Griglia semplice
 ja:
   home:
     sort:

--- a/lib/i18n/_missing_translations.yaml
+++ b/lib/i18n/_missing_translations.yaml
@@ -622,17 +622,6 @@ hu:
       masonryGrid(OUTDATED): Masonry grid
       simpleGrid(OUTDATED): Simple grid
 it:
-  home:
-    sort:
-      sortBy(OUTDATED): Ordina per
-      nameAToZ(OUTDATED): Nome (A-Z)
-      nameZToA(OUTDATED): Nome (Z-A)
-      lastModifiedNewToOld(OUTDATED): Modificato (Dal più recente)
-      lastModifiedOldToNew(OUTDATED): Modificato (Dal più vecchio)
-    layout:
-      layout(OUTDATED): Layout
-      masonryGrid(OUTDATED): Griglia a mosaico
-      simpleGrid(OUTDATED): Griglia semplice
 ja:
   home:
     sort:

--- a/lib/i18n/it.i18n.yaml
+++ b/lib/i18n/it.i18n.yaml
@@ -70,15 +70,15 @@ home:
     delete: Elimina
     alsoDeleteContents: Elimina anche tutte le note all'interno di questa cartella
   sort:
-    sortBy(OUTDATED): Ordina per
-    nameAToZ(OUTDATED): Nome (A-Z)
-    nameZToA(OUTDATED): Nome (A-Z)
-    lastModifiedNewToOld(OUTDATED): Modificato (Più recente per primo)
-    lastModifiedOldToNew(OUTDATED): Modificato (dal più vecchio al più recente)
+    sortBy: Ordina per
+    nameAToZ: Nome (A-Z)
+    nameZToA: Nome (Z-A)
+    lastModifiedNewToOld: Modificato (Dal più recente)
+    lastModifiedOldToNew: Modificato (Dal più vecchio)
   layout:
-    layout(OUTDATED): Layout
-    masonryGrid(OUTDATED): Griglia a muratura
-    simpleGrid(OUTDATED): Griglia semplice
+    layout: Layout
+    masonryGrid: Griglia a mosaico
+    simpleGrid: Griglia semplice
 sentry:
   consent:
     title: Vuoi aiutarci a migliorare Saber?

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -381,9 +381,9 @@ class _Translations$home$sort$it extends Translations$home$sort$en {
 	// Translations
 	@override String get sortBy => 'Ordina per';
 	@override String get nameAToZ => 'Nome (A-Z)';
-	@override String get nameZToA => 'Nome (A-Z)';
-	@override String get lastModifiedNewToOld => 'Modificato (Più recente per primo)';
-	@override String get lastModifiedOldToNew => 'Modificato (dal più vecchio al più recente)';
+	@override String get nameZToA => 'Nome (Z-A)';
+	@override String get lastModifiedNewToOld => 'Modificato (Dal più recente)';
+	@override String get lastModifiedOldToNew => 'Modificato (Dal più vecchio)';
 }
 
 // Path: home.layout
@@ -394,7 +394,7 @@ class _Translations$home$layout$it extends Translations$home$layout$en {
 
 	// Translations
 	@override String get layout => 'Layout';
-	@override String get masonryGrid => 'Griglia a muratura';
+	@override String get masonryGrid => 'Griglia a mosaico';
 	@override String get simpleGrid => 'Griglia semplice';
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Italian translations for Home sorting and layout, replacing outdated strings. Applied “Nome (A‑Z)/(Z‑A)”, “Modificato (Dal più recente/Dal più vecchio)”, “Griglia a mosaico”; removed `it` entries from `_missing_translations.yaml` and regenerated `strings_it.g.dart`.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 8d3a8a9eb7b5b9ba8821b7d36d650e5d2b0118b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

