### PR TITLE
Add Apple Pencil eraser toggle and enhanced image insertion on iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
+// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+
 import Flutter
 import UIKit
 import workmanager_apple
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  private let pencilInteractions = PencilInteractionHandler()
+
   /// Registers all pubspec-referenced Flutter plugins in the given registry
   static func registerPlugins(with registry: FlutterPluginRegistry) {
     GeneratedPluginRegistrant.register(with: registry)
@@ -26,5 +30,72 @@ import workmanager_apple
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     AppDelegate.registerPlugins(with: engineBridge.pluginRegistry)
+    pencilInteractions.setUp(messenger: engineBridge.applicationRegistrar.messenger())
+  }
+}
+
+/// Forwards Apple Pencil double-taps to Dart over a method channel,
+/// received by `ApplePencilInteractions` in lib/data/apple_pencil_interactions.dart.
+class PencilInteractionHandler: NSObject, UIPencilInteractionDelegate {
+  private var channel: FlutterMethodChannel?
+  private var interactionAttached = false
+
+  override init() {
+    super.init()
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(attachInteraction),
+      name: UIScene.didActivateNotification,
+      object: nil
+    )
+  }
+
+  func setUp(messenger: FlutterBinaryMessenger) {
+    channel = FlutterMethodChannel(
+      name: "com.adilhanney.saber/apple_pencil",
+      binaryMessenger: messenger
+    )
+  }
+
+  /// Attaches a UIPencilInteraction to the scene's window once the scene
+  /// becomes active. The window may not exist before then.
+  @objc private func attachInteraction(_ notification: Notification) {
+    guard !interactionAttached else { return }
+    guard let window = (notification.object as? UIWindowScene)?.windows.first else { return }
+
+    let interaction = UIPencilInteraction()
+    interaction.delegate = self
+    window.addInteraction(interaction)
+    interactionAttached = true
+  }
+
+  // Called on iOS versions before 17.5
+  func pencilInteractionDidTap(_ interaction: UIPencilInteraction) {
+    sendDoubleTap()
+  }
+
+  @available(iOS 17.5, *)
+  func pencilInteraction(
+    _ interaction: UIPencilInteraction,
+    didReceiveTap tap: UIPencilInteraction.Tap
+  ) {
+    sendDoubleTap()
+  }
+
+  /// Sends the double-tap to Dart along with the system-wide preferred tap
+  /// action, so that Dart can honor the "Off" (.ignore) system setting.
+  private func sendDoubleTap() {
+    channel?.invokeMethod("doubleTap", arguments: preferredTapActionName)
+  }
+
+  private var preferredTapActionName: String {
+    switch UIPencilInteraction.preferredTapAction {
+    case .ignore: return "ignore"
+    case .switchEraser: return "switchEraser"
+    case .switchPrevious: return "switchPrevious"
+    case .showColorPalette: return "showColorPalette"
+    case .showInkAttributes: return "showInkAttributes"
+    default: return "other"
+    }
   }
 }

--- a/lib/components/canvas/canvas_gesture_detector.dart
+++ b/lib/components/canvas/canvas_gesture_detector.dart
@@ -1,3 +1,6 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
 import 'dart:async';
 import 'dart:collection';
 import 'dart:math';
@@ -91,7 +94,7 @@ class CanvasGestureDetector extends StatefulWidget {
       /// is the minimum of the page width and the screen width.
       final pageWidthFitted = min(pageSize.width, screenWidth);
 
-      top += 16;
+      top += EditorPage.gapBetweenPages;
       top += pageSize.height * (pageWidthFitted / pageSize.width);
     }
 
@@ -133,7 +136,7 @@ class CanvasGestureDetector extends StatefulWidget {
       /// is the minimum of the page width and the screen width.
       final pageWidthFitted = min(pageSize.width, screenWidth);
 
-      top += 16;
+      top += EditorPage.gapBetweenPages;
       top += pageSize.height * (pageWidthFitted / pageSize.width);
 
       if (top > scrollY) return i;

--- a/lib/components/canvas/canvas_image.dart
+++ b/lib/components/canvas/canvas_image.dart
@@ -1,3 +1,6 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
 import 'dart:math';
 
 import 'package:defer_pointer/defer_pointer.dart';
@@ -6,6 +9,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:saber/components/canvas/canvas_image_dialog.dart';
 import 'package:saber/components/canvas/image/editor_image.dart';
 import 'package:saber/components/theming/adaptive_alert_dialog.dart';
+import 'package:saber/data/editor/page.dart';
 import 'package:saber/data/extensions/change_notifier_extensions.dart';
 import 'package:saber/data/prefs.dart';
 import 'package:saber/i18n/strings.g.dart';
@@ -134,6 +138,9 @@ class _CanvasImageState extends State<CanvasImage> {
                           widget.pageSize.width * 0.05,
                           widget.pageSize.height * 0.05,
                         );
+                        // The image may be dragged past the top or bottom of
+                        // the page to move it to the adjacent page
+                        // (see EditorState.onMoveImage).
                         widget.image.dstRect = .fromLTWH(
                           (widget.image.dstRect.left + details.delta.dx)
                               .clamp(
@@ -143,8 +150,10 @@ class _CanvasImageState extends State<CanvasImage> {
                               .toDouble(),
                           (widget.image.dstRect.top + details.delta.dy)
                               .clamp(
-                                fivePercent - widget.image.dstRect.height,
-                                widget.pageSize.height - fivePercent,
+                                -widget.image.dstRect.height -
+                                    EditorPage.gapBetweenPages,
+                                widget.pageSize.height +
+                                    EditorPage.gapBetweenPages,
                               )
                               .toDouble(),
                           widget.image.dstRect.width,

--- a/lib/components/toolbar/editor_bottom_sheet.dart
+++ b/lib/components/toolbar/editor_bottom_sheet.dart
@@ -1,3 +1,6 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:saber/components/canvas/canvas_background_preview.dart';
@@ -27,6 +30,7 @@ class EditorBottomSheet extends StatefulWidget {
     required this.clearAllPages,
     required this.redrawAndSave,
     required this.pickPhotos,
+    required this.pickPhotosFromFiles,
     required this.importPdf,
     required this.canRasterPdf,
     required this.getIsWatchingServer,
@@ -45,6 +49,11 @@ class EditorBottomSheet extends StatefulWidget {
   final VoidCallback clearAllPages;
   final VoidCallback redrawAndSave;
   final Future<int> Function() pickPhotos;
+
+  /// Picks photos with the file picker, on platforms where [pickPhotos]
+  /// uses the photo library instead. If null, no button is shown.
+  final Future<int> Function()? pickPhotosFromFiles;
+
   final Future<bool> Function() importPdf;
   final bool canRasterPdf;
   final bool Function() getIsWatchingServer;
@@ -303,6 +312,17 @@ class _EditorBottomSheetState extends State<EditorBottomSheet> {
                   },
                   child: Text(t.editor.toolbar.photo),
                 ),
+                if (widget.pickPhotosFromFiles != null)
+                  ElevatedButton(
+                    onPressed: () async {
+                      final photosPicked = await widget.pickPhotosFromFiles!();
+                      if (photosPicked > 0) {
+                        if (!context.mounted) return;
+                        Navigator.pop(context);
+                      }
+                    },
+                    child: Text(t.editor.toolbar.photoFromFile),
+                  ),
                 if (widget.canRasterPdf)
                   ElevatedButton(
                     onPressed: () async {

--- a/lib/components/toolbar/toolbar.dart
+++ b/lib/components/toolbar/toolbar.dart
@@ -1,3 +1,6 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
 import 'dart:io';
 
 import 'package:collapsible/collapsible.dart';
@@ -45,6 +48,7 @@ class Toolbar extends StatefulWidget {
     required this.isRedoPossible,
     required this.toggleFingerDrawing,
     required this.pickPhoto,
+    required this.pickPhotoFromFile,
     required this.paste,
     required this.duplicateSelection,
     required this.deleteSelection,
@@ -71,6 +75,10 @@ class Toolbar extends StatefulWidget {
   final VoidCallback toggleFingerDrawing;
 
   final VoidCallback pickPhoto;
+
+  /// Picks a photo with the file picker, on platforms where [pickPhoto]
+  /// uses the photo library instead. If null, no button is shown.
+  final VoidCallback? pickPhotoFromFile;
 
   final VoidCallback paste;
 
@@ -466,6 +474,17 @@ class _ToolbarState extends State<Toolbar> {
                   cupertinoIcon: CupertinoIcons.photo,
                 ),
               ),
+              if (widget.pickPhotoFromFile != null)
+                ToolbarIconButton(
+                  tooltip: t.editor.toolbar.photoFromFile,
+                  enabled: !widget.readOnly,
+                  onPressed: widget.pickPhotoFromFile,
+                  padding: buttonPadding,
+                  child: const AdaptiveIcon(
+                    icon: Icons.folder_open,
+                    cupertinoIcon: CupertinoIcons.folder_open,
+                  ),
+                ),
               ToolbarIconButton(
                 tooltip: t.editor.toolbar.text,
                 selected: widget.textEditing,

--- a/lib/data/apple_pencil_interactions.dart
+++ b/lib/data/apple_pencil_interactions.dart
@@ -1,0 +1,34 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
+import 'package:flutter/services.dart';
+
+/// Receives Apple Pencil interaction events from the iOS runner,
+/// sent over [channel] by `PencilInteractionHandler` in AppDelegate.swift.
+abstract final class ApplePencilInteractions {
+  static const channel = MethodChannel('com.adilhanney.saber/apple_pencil');
+
+  /// Called when the user double-taps the side of their Apple Pencil.
+  static VoidCallback? onDoubleTap;
+
+  static var _initialized = false;
+
+  /// Starts listening to [channel]. Safe to call multiple times.
+  static void init() {
+    if (_initialized) return;
+    _initialized = true;
+    channel.setMethodCallHandler(_onMethodCall);
+  }
+
+  /// Handles a call from the iOS runner. `doubleTap` calls come with the
+  /// user's preferred tap action from the system-wide Apple Pencil settings:
+  /// `ignore` means the user turned double-tap off, and any other action is
+  /// mapped to Saber's pen/eraser toggle.
+  static Future<void> _onMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'doubleTap':
+        if (call.arguments == 'ignore') return;
+        onDoubleTap?.call();
+    }
+  }
+}

--- a/lib/data/editor/editor_history.dart
+++ b/lib/data/editor/editor_history.dart
@@ -1,3 +1,6 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:saber/components/canvas/_stroke.dart';
@@ -149,6 +152,7 @@ class EditorHistoryItem {
     this.quillChange,
     this.colorChange,
     this.backgroundPatternChange,
+    this.imagePageChange,
   }) : assert(
          type != .move || offset != null,
          'Offset must be provided for move',
@@ -188,6 +192,10 @@ class EditorHistoryItem {
   final Map<Stroke, Change<Color>>? colorChange;
   final Change<CanvasBackgroundPattern>? backgroundPatternChange;
 
+  /// For [EditorHistoryItemType.move] items whose [images] were dragged
+  /// onto another page, the change in the images' page index.
+  final Change<int>? imagePageChange;
+
   EditorHistoryItem copyWith({
     EditorHistoryItemType? type,
     int? pageIndex,
@@ -198,6 +206,7 @@ class EditorHistoryItem {
     DocChange? quillChange,
     Map<Stroke, Change<Color>>? colorChange,
     Change<CanvasBackgroundPattern>? backgroundPatternChange,
+    Change<int>? imagePageChange,
   }) {
     return EditorHistoryItem(
       type: type ?? this.type,
@@ -210,6 +219,7 @@ class EditorHistoryItem {
       colorChange: colorChange ?? this.colorChange,
       backgroundPatternChange:
           backgroundPatternChange ?? this.backgroundPatternChange,
+      imagePageChange: imagePageChange ?? this.imagePageChange,
     );
   }
 }

--- a/lib/data/editor/page.dart
+++ b/lib/data/editor/page.dart
@@ -1,3 +1,6 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
 import 'dart:async';
 import 'dart:math';
 import 'dart:typed_data';
@@ -20,6 +23,9 @@ class EditorPage extends ChangeNotifier implements HasSize {
   static const double defaultWidth = 1000;
   static const double defaultHeight = defaultWidth * 1.4;
   static const defaultSize = Size(defaultWidth, defaultHeight);
+
+  /// The vertical gap between pages on the canvas.
+  static const double gapBetweenPages = 16;
 
   @override
   final Size size;

--- a/lib/i18n/en.i18n.yaml
+++ b/lib/i18n/en.i18n.yaml
@@ -272,6 +272,7 @@ editor:
     select: Select
     toggleEraser: Toggle eraser (Ctrl E)
     photo: Images
+    photoFromFile: Insert from Files
     text: Text
     toggleFingerDrawing: Toggle finger drawing (Ctrl F)
     undo: Undo

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -1063,6 +1063,9 @@ class Translations$editor$toolbar$en {
 	/// en: 'Images'
 	String get photo => 'Images';
 
+	/// en: 'Insert from Files'
+	String get photoFromFile => 'Insert from Files';
+
 	/// en: 'Text'
 	String get text => 'Text';
 

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -1,15 +1,20 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:collapsible/collapsible.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kDebugMode;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart' as flutter_quill;
+import 'package:image_picker/image_picker.dart';
 import 'package:keybinder/keybinder.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -30,6 +35,7 @@ import 'package:saber/components/toolbar/color_bar.dart';
 import 'package:saber/components/toolbar/editor_bottom_sheet.dart';
 import 'package:saber/components/toolbar/editor_page_manager.dart';
 import 'package:saber/components/toolbar/toolbar.dart';
+import 'package:saber/data/apple_pencil_interactions.dart';
 import 'package:saber/data/editor/editor_core_info.dart';
 import 'package:saber/data/editor/editor_exporter.dart';
 import 'package:saber/data/editor/editor_history.dart';
@@ -91,6 +97,11 @@ class Editor extends StatefulWidget {
 
   /// Whether the platform can rasterize a pdf
   static var canRasterPdf = true;
+
+  /// Whether photos are picked from the system photo library by default,
+  /// with the file picker offered as a secondary option.
+  static bool get picksPhotosFromLibrary =>
+      defaultTargetPlatform == TargetPlatform.iOS;
 
   @override
   State<Editor> createState() => EditorState();
@@ -160,6 +171,29 @@ class EditorState extends State<Editor> {
     stows.lastTool.value = tool.toolId;
   }
 
+  /// Sets the current tool, e.g. from the toolbar or an Apple Pencil
+  /// double-tap.
+  ///
+  /// As a special case, calling `setTool(Eraser())` while the eraser is
+  /// already selected toggles it off and restores the previous tool.
+  void setTool(Tool tool) {
+    if (tool is Eraser && currentTool is Eraser) {
+      tool = _lastNonEraserTool;
+    }
+
+    currentTool = tool;
+
+    if (tool is Highlighter) {
+      Highlighter.currentHighlighter = tool;
+    } else if (tool is Pencil) {
+      Pencil.currentPencil = tool;
+    } else if (tool is Pen) {
+      Pen.currentPen = tool;
+    }
+
+    if (mounted) setState(() {});
+  }
+
   ValueNotifier<SavingState> savingState = ValueNotifier(SavingState.saved);
   Timer? _delayedSaveTimer;
   Timer? _watchServerTimer;
@@ -184,10 +218,20 @@ class EditorState extends State<Editor> {
   void initState() {
     DynamicMaterialApp.addFullscreenListener(_setState);
 
+    ApplePencilInteractions.init();
+    ApplePencilInteractions.onDoubleTap = _onPencilDoubleTap;
+
     _initAsync();
     _assignKeybindings();
 
     super.initState();
+  }
+
+  /// Toggles between the eraser and the previous tool
+  /// when the user double-taps their Apple Pencil.
+  void _onPencilDoubleTap() {
+    if (coreInfo.readOnly) return;
+    setTool(Eraser());
   }
 
   void _initAsync() async {
@@ -410,6 +454,15 @@ class EditorState extends State<Editor> {
               Offset(-item.offset!.left, -item.offset!.top),
             );
           }
+          if (item.imagePageChange != null) {
+            for (final image in item.images) {
+              coreInfo.pages[item.imagePageChange!.current].images.remove(
+                image,
+              );
+              coreInfo.pages[item.imagePageChange!.previous].images.add(image);
+              image.pageIndex = item.imagePageChange!.previous;
+            }
+          }
           for (final image in item.images) {
             image.dstRect = .fromLTRB(
               image.dstRect.left - item.offset!.left,
@@ -466,6 +519,12 @@ class EditorState extends State<Editor> {
               -item.offset!.right,
               -item.offset!.bottom,
             ),
+            imagePageChange: item.imagePageChange == null
+                ? null
+                : Change(
+                    previous: item.imagePageChange!.current,
+                    current: item.imagePageChange!.previous,
+                  ),
           ),
         );
       case .quillChange:
@@ -762,6 +821,17 @@ class EditorState extends State<Editor> {
   }
 
   void onMoveImage(EditorImage image, Rect offset) {
+    final rectBeforeTransfer = image.dstRect;
+    final pageChange = _transferMovedImageAcrossPages(image);
+    if (image.dstRect != rectBeforeTransfer) {
+      offset = Rect.fromLTRB(
+        offset.left + image.dstRect.left - rectBeforeTransfer.left,
+        offset.top + image.dstRect.top - rectBeforeTransfer.top,
+        offset.right + image.dstRect.right - rectBeforeTransfer.right,
+        offset.bottom + image.dstRect.bottom - rectBeforeTransfer.bottom,
+      );
+    }
+
     history.recordChange(
       EditorHistoryItem(
         type: .move,
@@ -769,11 +839,72 @@ class EditorState extends State<Editor> {
         strokes: [],
         images: [image],
         offset: offset,
+        imagePageChange: pageChange,
       ),
     );
     // setState to update undo button
     setState(() {});
     autosaveAfterDelay();
+  }
+
+  /// If [image] was dragged so that its center is past the top or bottom
+  /// edge of its page, moves it to the adjacent page.
+  ///
+  /// Returns the change in the image's page index,
+  /// or null if the image stayed on its page.
+  Change<int>? _transferMovedImageAcrossPages(EditorImage image) {
+    final pageIndex = image.pageIndex;
+    final pageSize = coreInfo.pages[pageIndex].size;
+    final center = image.dstRect.center;
+
+    final int newPageIndex;
+    if (center.dy < 0 && pageIndex > 0) {
+      newPageIndex = pageIndex - 1;
+    } else if (center.dy > pageSize.height &&
+        pageIndex + 1 < coreInfo.pages.length) {
+      newPageIndex = pageIndex + 1;
+    } else {
+      _clampImageWithinPage(image);
+      return null;
+    }
+
+    final newPageSize = coreInfo.pages[newPageIndex].size;
+    final newTop = newPageIndex > pageIndex
+        ? image.dstRect.top - pageSize.height - EditorPage.gapBetweenPages
+        : image.dstRect.top + newPageSize.height + EditorPage.gapBetweenPages;
+    image.dstRect = Rect.fromLTWH(
+      image.dstRect.left,
+      newTop,
+      image.dstRect.width,
+      image.dstRect.height,
+    );
+
+    coreInfo.pages[pageIndex].images.remove(image);
+    coreInfo.pages[newPageIndex].images.add(image);
+    image.pageIndex = newPageIndex;
+
+    _clampImageWithinPage(image);
+    return Change(previous: pageIndex, current: newPageIndex);
+  }
+
+  /// Clamps [image]'s position so that at least a sliver of it
+  /// is visible on its page, mirroring the drag clamp in CanvasImage.
+  void _clampImageWithinPage(EditorImage image) {
+    final pageSize = coreInfo.pages[image.pageIndex].size;
+    final rect = image.dstRect;
+    if (!rect.left.isFinite || !rect.top.isFinite) return;
+    if (!rect.width.isFinite || !rect.height.isFinite) return;
+    final fivePercent = min(pageSize.width, pageSize.height) * 0.05;
+
+    final left = rect.left
+        .clamp(fivePercent - rect.width, pageSize.width - fivePercent)
+        .toDouble();
+    final top = rect.top
+        .clamp(fivePercent - rect.height, pageSize.height - fivePercent)
+        .toDouble();
+    if (left == rect.left && top == rect.top) return;
+
+    image.dstRect = Rect.fromLTWH(left, top, rect.width, rect.height);
   }
 
   void onDeleteImage(EditorImage image) {
@@ -1083,16 +1214,20 @@ class EditorState extends State<Editor> {
     }
   }
 
-  /// Prompts the user to pick photos from their device.
+  /// Prompts the user to pick photos from their device:
+  /// from the photo library if [Editor.picksPhotosFromLibrary],
+  /// or with the file picker otherwise.
   /// Returns the number of photos picked.
   ///
-  /// If [photoInfos] is provided, it will be used instead of the file picker.
+  /// If [photoInfos] is provided, it will be used instead of a picker.
   Future<int> _pickPhotos([List<_PhotoInfo>? photoInfos]) async {
     if (coreInfo.readOnly) return 0;
 
     final currentPageIndex = this.currentPageIndex;
 
-    photoInfos ??= await _pickPhotosWithFilePicker();
+    photoInfos ??= Editor.picksPhotosFromLibrary
+        ? await _pickPhotosWithPhotosPicker()
+        : await _pickPhotosWithFilePicker();
     if (photoInfos.isEmpty) return 0;
 
     // use the Select tool so that the user can move the new image
@@ -1107,6 +1242,7 @@ class EditorState extends State<Editor> {
             svgFile: null,
             pageIndex: currentPageIndex,
             pageSize: coreInfo.pages[currentPageIndex].size,
+            invertible: false,
             onMoveImage: onMoveImage,
             onDeleteImage: onDeleteImage,
             onMiscChange: autosaveAfterDelay,
@@ -1120,6 +1256,7 @@ class EditorState extends State<Editor> {
             imageProvider: MemoryImage(photoInfo.bytes),
             pageIndex: currentPageIndex,
             pageSize: coreInfo.pages[currentPageIndex].size,
+            invertible: false,
             onMoveImage: onMoveImage,
             onDeleteImage: onDeleteImage,
             onMiscChange: autosaveAfterDelay,
@@ -1143,27 +1280,89 @@ class EditorState extends State<Editor> {
     return images.length;
   }
 
+  /// Prompts the user to pick images or PDFs with the file picker, on
+  /// platforms where [_pickPhotos] uses the photo library instead.
+  /// Returns the number of images and PDFs inserted.
+  Future<int> _pickPhotosFromFiles() async {
+    if (coreInfo.readOnly) return 0;
+
+    final FilePickerResult? result = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: [
+        ..._imageFileExtensions,
+        if (Editor.canRasterPdf) 'pdf',
+      ],
+      allowMultiple: true,
+      withData: true,
+    );
+    if (result == null) return 0;
+
+    return insertPickedFiles(result.files);
+  }
+
+  /// Inserts images and PDFs picked with the file picker.
+  /// Returns the number of images and PDFs inserted.
+  @visibleForTesting
+  Future<int> insertPickedFiles(List<PlatformFile> files) async {
+    var pdfsImported = 0;
+    final photoInfos = <_PhotoInfo>[];
+
+    for (final PlatformFile file in files) {
+      if (file.extension?.toLowerCase() == 'pdf') {
+        if (file.path == null) continue;
+        if (await importPdfFromFilePath(file.path!)) pdfsImported++;
+      } else if (file.bytes != null && file.extension != null) {
+        photoInfos.add((bytes: file.bytes!, extension: '.${file.extension}'));
+      }
+    }
+
+    return pdfsImported + await _pickPhotos(photoInfos);
+  }
+
+  Future<List<_PhotoInfo>> _pickPhotosWithPhotosPicker() async {
+    final images = await ImagePicker().pickMultiImage(
+      requestFullMetadata: false,
+    );
+
+    return [
+      for (final XFile image in images)
+        (bytes: await image.readAsBytes(), extension: _imageExtensionOf(image)),
+    ];
+  }
+
+  /// The file extension of a picked [image], e.g. `.jpg`,
+  /// or `.png` if the picker provided no usable file name.
+  static String _imageExtensionOf(XFile image) {
+    for (final name in [image.name, image.path]) {
+      final extension = p.extension(name).toLowerCase();
+      if (extension.startsWith('.')) return extension;
+    }
+    return '.png';
+  }
+
+  /// Image file extensions supported by the file picker, taken from
+  /// https://github.com/brendan-duncan/image/blob/main/doc/formats.md
+  /// (plus .svg).
+  static const _imageFileExtensions = [
+    'jpg',
+    'jpeg',
+    'png',
+    'gif',
+    'tiff',
+    'bmp',
+    'tga',
+    'ico',
+    'pvrtc',
+    'svg',
+    'webp',
+    'psd',
+    'exr',
+  ];
+
   Future<List<_PhotoInfo>> _pickPhotosWithFilePicker() async {
     final FilePickerResult? result = await FilePicker.pickFiles(
       type: FileType.custom,
-      // Taken from
-      // https://github.com/brendan-duncan/image/blob/main/doc/formats.md
-      // (plus .svg)
-      allowedExtensions: [
-        'jpg',
-        'jpeg',
-        'png',
-        'gif',
-        'tiff',
-        'bmp',
-        'tga',
-        'ico',
-        'pvrtc',
-        'svg',
-        'webp',
-        'psd',
-        'exr',
-      ],
+      allowedExtensions: _imageFileExtensions,
       allowMultiple: true,
       withData: true,
     );
@@ -1423,24 +1622,7 @@ class EditorState extends State<Editor> {
         bottom: stows.editorToolbarAlignment.value != AxisDirection.up,
         child: Toolbar(
           readOnly: coreInfo.readOnly,
-          setTool: (tool) {
-            if (tool is Eraser && currentTool is Eraser) {
-              // setTool(Eraser) is a special case to toggle the eraser on/off
-              tool = _lastNonEraserTool;
-            }
-
-            currentTool = tool;
-
-            if (tool is Highlighter) {
-              Highlighter.currentHighlighter = tool;
-            } else if (tool is Pencil) {
-              Pencil.currentPencil = tool;
-            } else if (tool is Pen) {
-              Pen.currentPen = tool;
-            }
-
-            if (mounted) setState(() {});
-          },
+          setTool: setTool,
           currentTool: currentTool,
           duplicateSelection: () {
             final select = currentTool as Select;
@@ -1580,6 +1762,9 @@ class EditorState extends State<Editor> {
             lastSeenPointerCount = 0;
           },
           pickPhoto: _pickPhotos,
+          pickPhotoFromFile: Editor.picksPhotosFromLibrary
+              ? _pickPhotosFromFiles
+              : null,
           paste: paste,
           exportAsSba: exportAsSba,
           exportAsPdf: exportAsPdf,
@@ -1802,6 +1987,9 @@ class EditorState extends State<Editor> {
         autosaveAfterDelay();
       }),
       pickPhotos: _pickPhotos,
+      pickPhotosFromFiles: Editor.picksPhotosFromLibrary
+          ? _pickPhotosFromFiles
+          : null,
       importPdf: importPdf,
       canRasterPdf: Editor.canRasterPdf,
       getIsWatchingServer: () => _watchServerTimer?.isActive ?? false,
@@ -2030,11 +2218,12 @@ class EditorState extends State<Editor> {
   int get currentPageIndex {
     if (!mounted) return _lastCurrentPageIndex;
 
-    final screenWidth = MediaQuery.sizeOf(context).width;
+    final screenSize = MediaQuery.sizeOf(context);
+    final scale = _transformationController.value.approxScale;
 
     return _lastCurrentPageIndex = getPageIndexFromScrollPosition(
-      scrollY: -scrollY,
-      screenWidth: screenWidth,
+      scrollY: -scrollY + screenSize.height / 2 / scale,
+      screenWidth: screenSize.width,
       pages: coreInfo.pages,
     );
   }
@@ -2065,6 +2254,10 @@ class EditorState extends State<Editor> {
     unawaited(_cleanUpAsync());
 
     DynamicMaterialApp.removeFullscreenListener(_setState);
+
+    if (ApplePencilInteractions.onDoubleTap == _onPencilDoubleTap) {
+      ApplePencilInteractions.onDoubleTap = null;
+    }
 
     _delayedSaveTimer?.cancel();
     _watchServerTimer?.cancel();

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import desktop_webview_window
 import device_info_plus
 import dynamic_color
 import file_picker
+import file_selector_macos
 import flutter_secure_storage_darwin
 import flutter_web_auth_2
 import irondash_engine_context
@@ -30,6 +31,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -385,6 +385,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -744,6 +752,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+19"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: "direct dev"
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   ini:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   pdf: ^3.8.4
   share_plus: ^12.0.0
   file_picker: ^11.0.2
+  image_picker: ^1.2.0
 
   regexed_validator: ^2.0.0+1
 
@@ -176,6 +177,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
   icons_launcher: ^3.0.0
+
+  image_picker_platform_interface: any
 
   yaml: ^3.1.2
 

--- a/test/apple_pencil_double_tap_test.dart
+++ b/test/apple_pencil_double_tap_test.dart
@@ -1,0 +1,79 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saber/data/apple_pencil_interactions.dart';
+import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/data/flavor_config.dart';
+import 'package:saber/data/tools/eraser.dart';
+import 'package:saber/data/tools/pen.dart';
+import 'package:saber/pages/editor/editor.dart';
+
+import 'utils/test_mock_channel_handlers.dart';
+
+void main() {
+  group('Apple Pencil double-tap', () {
+    /// Simulates the iOS runner sending a double-tap over the method channel,
+    /// with [preferredAction] being the system-wide Apple Pencil setting.
+    Future<void> doubleTapPencil(
+      WidgetTester tester, {
+      String preferredAction = 'switchEraser',
+    }) async {
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            ApplePencilInteractions.channel.name,
+            const StandardMethodCodec().encodeMethodCall(
+              MethodCall('doubleTap', preferredAction),
+            ),
+            (_) {},
+          );
+      await tester.pump();
+    }
+
+    Future<EditorState> pumpEditor(WidgetTester tester) async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      setupMockPathProvider();
+      FlavorConfig.setup();
+      await tester.runAsync(FileManager.init);
+
+      await tester.pumpWidget(MaterialApp(home: Editor()));
+      final state = tester.state<EditorState>(find.byType(Editor));
+      addTearDown(state.cancelAutosaveAndMarkSaved);
+
+      for (var i = 0; i < 10 && state.coreInfo.readOnly; i++) {
+        await tester.pump();
+      }
+      expect(
+        state.coreInfo.readOnly,
+        isFalse,
+        reason: 'New file should not be read-only',
+      );
+
+      state.setTool(Pen.currentPen);
+      return state;
+    }
+
+    testWidgets('toggles between pen and eraser', (tester) async {
+      final state = await pumpEditor(tester);
+      expect(state.currentTool, isA<Pen>());
+
+      await doubleTapPencil(tester);
+      expect(state.currentTool, isA<Eraser>());
+
+      await doubleTapPencil(tester);
+      expect(state.currentTool, isA<Pen>());
+    });
+
+    testWidgets('does nothing if disabled in the system settings', (
+      tester,
+    ) async {
+      final state = await pumpEditor(tester);
+      expect(state.currentTool, isA<Pen>());
+
+      await doubleTapPencil(tester, preferredAction: 'ignore');
+      expect(state.currentTool, isA<Pen>());
+    });
+  });
+}

--- a/test/insert_photos_test.dart
+++ b/test/insert_photos_test.dart
@@ -1,0 +1,129 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:saber/components/canvas/image/editor_image.dart';
+import 'package:saber/components/toolbar/toolbar.dart';
+import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/data/flavor_config.dart';
+import 'package:saber/data/tools/select.dart';
+import 'package:saber/i18n/strings.g.dart';
+import 'package:saber/pages/editor/editor.dart';
+
+import 'utils/test_mock_channel_handlers.dart';
+
+/// A 1x1 transparent png.
+final _pngBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA'
+  'DUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+);
+
+class _FakeImagePickerPlatform extends ImagePickerPlatform {
+  var pickCalls = 0;
+
+  @override
+  Future<List<XFile>> getMultiImageWithOptions({
+    MultiImagePickerOptions options = const MultiImagePickerOptions(),
+  }) async {
+    pickCalls++;
+    return [XFile.fromData(_pngBytes, name: 'picked.png')];
+  }
+}
+
+void main() {
+  group('Inserting photos', () {
+    Future<EditorState> pumpEditor(WidgetTester tester) async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      setupMockPathProvider();
+      FlavorConfig.setup();
+      await tester.runAsync(FileManager.init);
+
+      await tester.pumpWidget(MaterialApp(home: Editor()));
+      final state = tester.state<EditorState>(find.byType(Editor));
+      addTearDown(state.cancelAutosaveAndMarkSaved);
+
+      for (var i = 0; i < 10 && state.coreInfo.readOnly; i++) {
+        await tester.pump();
+      }
+      expect(
+        state.coreInfo.readOnly,
+        isFalse,
+        reason: 'New file should not be read-only',
+      );
+      return state;
+    }
+
+    testWidgets(
+      'uses the photo library on iOS',
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      (tester) async {
+        EditorImage.shouldLoadOutImmediately = true;
+        addTearDown(() => EditorImage.shouldLoadOutImmediately = false);
+
+        final fakePicker = _FakeImagePickerPlatform();
+        ImagePickerPlatform.instance = fakePicker;
+
+        final state = await pumpEditor(tester);
+        final toolbar = tester.widget<Toolbar>(find.byType(Toolbar));
+        expect(
+          toolbar.pickPhotoFromFile,
+          isNotNull,
+          reason: 'iOS should offer a separate insert-from-Files button',
+        );
+        expect(find.byTooltip(t.editor.toolbar.photoFromFile), findsOneWidget);
+
+        toolbar.pickPhoto();
+        await tester.pump();
+        await tester.pump();
+
+        expect(fakePicker.pickCalls, 1);
+        expect(state.coreInfo.pages.first.images, hasLength(1));
+        expect(
+          state.coreInfo.pages.first.images.single.invertible,
+          isFalse,
+          reason: 'Inserted photos should keep their original colors',
+        );
+        expect(
+          state.currentTool,
+          isA<Select>(),
+          reason: 'The select tool lets the user move the inserted image',
+        );
+      },
+    );
+
+    testWidgets('offers no insert-from-Files button on other platforms', (
+      tester,
+    ) async {
+      await pumpEditor(tester);
+      final toolbar = tester.widget<Toolbar>(find.byType(Toolbar));
+      expect(toolbar.pickPhotoFromFile, isNull);
+      expect(find.byTooltip(t.editor.toolbar.photoFromFile), findsNothing);
+    });
+
+    testWidgets('inserts images picked from Files with original colors', (
+      tester,
+    ) async {
+      EditorImage.shouldLoadOutImmediately = true;
+      addTearDown(() => EditorImage.shouldLoadOutImmediately = false);
+
+      final state = await pumpEditor(tester);
+      final inserted = await state.insertPickedFiles([
+        PlatformFile(
+          name: 'picked.png',
+          size: _pngBytes.length,
+          bytes: _pngBytes,
+        ),
+      ]);
+      await tester.pump();
+
+      expect(inserted, 1);
+      expect(state.coreInfo.pages.first.images, hasLength(1));
+      expect(state.coreInfo.pages.first.images.single.invertible, isFalse);
+    });
+  });
+}

--- a/test/move_image_across_pages_test.dart
+++ b/test/move_image_across_pages_test.dart
@@ -1,0 +1,140 @@
+/// 🤖 Generated wholely or partially with Claude Code (Claude Fable 5)
+library;
+
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saber/components/canvas/image/editor_image.dart';
+import 'package:saber/data/editor/page.dart';
+import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/data/flavor_config.dart';
+import 'package:saber/pages/editor/editor.dart';
+
+import 'utils/test_mock_channel_handlers.dart';
+
+/// A 1x1 transparent png.
+final _pngBytes = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA'
+  'DUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+);
+
+void main() {
+  group('Moving an image across pages', () {
+    testWidgets('transfers, undoes, and redoes', (tester) async {
+      EditorImage.shouldLoadOutImmediately = true;
+      addTearDown(() => EditorImage.shouldLoadOutImmediately = false);
+
+      TestWidgetsFlutterBinding.ensureInitialized();
+      setupMockPathProvider();
+      FlavorConfig.setup();
+      await tester.runAsync(FileManager.init);
+
+      await tester.pumpWidget(MaterialApp(home: Editor()));
+      final state = tester.state<EditorState>(find.byType(Editor));
+      addTearDown(state.cancelAutosaveAndMarkSaved);
+
+      for (var i = 0; i < 10 && state.coreInfo.readOnly; i++) {
+        await tester.pump();
+      }
+      expect(state.coreInfo.readOnly, isFalse);
+
+      final inserted = await state.insertPickedFiles([
+        PlatformFile(
+          name: 'picked.png',
+          size: _pngBytes.length,
+          bytes: _pngBytes,
+        ),
+      ]);
+      expect(inserted, 1);
+      final image = state.coreInfo.pages.first.images.single;
+      expect(image.pageIndex, 0);
+
+      while (state.coreInfo.pages.length < 2) {
+        state.coreInfo.pages.add(EditorPage());
+      }
+
+      // Size the image like it would be once loaded.
+      image.dstRect = const Rect.fromLTWH(100, 100, 200, 150);
+      final startRect = image.dstRect;
+      final pageHeight = state.coreInfo.pages.first.size.height;
+
+      // Simulate a drag that leaves the image's center past the page bottom,
+      // like CanvasImage does before calling onMoveImage.
+      final dy = pageHeight + EditorPage.gapBetweenPages - startRect.top;
+      image.dstRect = startRect.translate(0, dy);
+      state.onMoveImage(image, Rect.fromLTRB(0, dy, 0, dy));
+      await tester.pump();
+
+      expect(image.pageIndex, 1);
+      expect(state.coreInfo.pages[0].images, isEmpty);
+      expect(state.coreInfo.pages[1].images, contains(image));
+
+      state.undo();
+      await tester.pump();
+      expect(image.pageIndex, 0);
+      expect(state.coreInfo.pages[0].images, contains(image));
+      expect(state.coreInfo.pages[1].images, isEmpty);
+      expect(image.dstRect, rectMoreOrLessEquals(startRect));
+
+      state.redo();
+      await tester.pump();
+      expect(image.pageIndex, 1);
+      expect(state.coreInfo.pages[0].images, isEmpty);
+      expect(state.coreInfo.pages[1].images, contains(image));
+    });
+
+    testWidgets('stays on the last page if there is no next page', (
+      tester,
+    ) async {
+      EditorImage.shouldLoadOutImmediately = true;
+      addTearDown(() => EditorImage.shouldLoadOutImmediately = false);
+
+      TestWidgetsFlutterBinding.ensureInitialized();
+      setupMockPathProvider();
+      FlavorConfig.setup();
+      await tester.runAsync(FileManager.init);
+
+      await tester.pumpWidget(MaterialApp(home: Editor()));
+      final state = tester.state<EditorState>(find.byType(Editor));
+      addTearDown(state.cancelAutosaveAndMarkSaved);
+
+      for (var i = 0; i < 10 && state.coreInfo.readOnly; i++) {
+        await tester.pump();
+      }
+
+      final inserted = await state.insertPickedFiles([
+        PlatformFile(
+          name: 'picked.png',
+          size: _pngBytes.length,
+          bytes: _pngBytes,
+        ),
+      ]);
+      expect(inserted, 1);
+
+      final lastPageIndex = state.coreInfo.pages.length - 1;
+      final image = state.coreInfo.pages.first.images.single;
+      state.coreInfo.pages.first.images.remove(image);
+      state.coreInfo.pages[lastPageIndex].images.add(image);
+      image.pageIndex = lastPageIndex;
+
+      final pageSize = state.coreInfo.pages[lastPageIndex].size;
+      image.dstRect = Rect.fromLTWH(
+        0,
+        pageSize.height + EditorPage.gapBetweenPages,
+        200,
+        150,
+      );
+      state.onMoveImage(image, Rect.zero);
+      await tester.pump();
+
+      expect(image.pageIndex, lastPageIndex);
+      expect(
+        image.dstRect.top,
+        lessThanOrEqualTo(pageSize.height),
+        reason: 'The image should be clamped back onto its page',
+      );
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the iOS runner, gesture handling, image/page management, and toolbar UI. The most significant changes are the addition of Apple Pencil double-tap support on iOS, improvements to image drag-and-drop between pages, and the introduction of a new toolbar option to insert images from files (not just the photo library). There are also minor refactors and documentation improvements.

**Apple Pencil Integration:**

- Added a `PencilInteractionHandler` to `AppDelegate.swift` to forward Apple Pencil double-tap events from iOS to Dart over a method channel, allowing Dart code to respond appropriately based on the user's system settings. (`ios/Runner/AppDelegate.swift`, `lib/data/apple_pencil_interactions.dart`) [[1]](diffhunk://#diff-2d8ca8a3da302654c934d7f3be4c2f6c8edc7788f2b8ed0178730d6d703ebe72R1-R10) [[2]](diffhunk://#diff-2d8ca8a3da302654c934d7f3be4c2f6c8edc7788f2b8ed0178730d6d703ebe72R33-R99) [[3]](diffhunk://#diff-35eecd62193af137ed41aeb6c74f65b8162fae31a77f3cebc7f48df2d0cf0279R1-R34)

**Toolbar and Image Insertion Improvements:**

- Added support for inserting images from files (not just the photo library) by introducing new callbacks and UI buttons in both the main toolbar and the bottom sheet. The new option is only shown on platforms where the photo library is the default picker (e.g., iOS). (`lib/components/toolbar/toolbar.dart`, `lib/components/toolbar/editor_bottom_sheet.dart`, `lib/pages/editor/editor.dart`, `lib/i18n/en.i18n.yaml`, `lib/i18n/strings_en.g.dart`) [[1]](diffhunk://#diff-2cef952a2ccfc933faab8348136619d4023ad926af8248154c7f85bc22fc7ebbR1-R3) [[2]](diffhunk://#diff-2cef952a2ccfc933faab8348136619d4023ad926af8248154c7f85bc22fc7ebbR51) [[3]](diffhunk://#diff-2cef952a2ccfc933faab8348136619d4023ad926af8248154c7f85bc22fc7ebbR79-R82) [[4]](diffhunk://#diff-2cef952a2ccfc933faab8348136619d4023ad926af8248154c7f85bc22fc7ebbR477-R487) [[5]](diffhunk://#diff-bb7bcb4c4de82a9fdde9853e32f59a85d15361d06038c83d5654fc01fadd1744R1-R3) [[6]](diffhunk://#diff-bb7bcb4c4de82a9fdde9853e32f59a85d15361d06038c83d5654fc01fadd1744R33) [[7]](diffhunk://#diff-bb7bcb4c4de82a9fdde9853e32f59a85d15361d06038c83d5654fc01fadd1744R52-R56) [[8]](diffhunk://#diff-bb7bcb4c4de82a9fdde9853e32f59a85d15361d06038c83d5654fc01fadd1744R315-R325) [[9]](diffhunk://#diff-9a194fe24f25ea5e2b2323ed2e42c784633358129095624f76e91829f4c174a2R101-R105) [[10]](diffhunk://#diff-d61513f61c535d1c9972519c37d7d06dcce1383cb6c1e30b42a9f11c90a908e6R275) [[11]](diffhunk://#diff-b2d274fd950fd2737eed5fa3ea0cf78c31ce16041580f4113d8f4e0e1d8d0078R1066-R1068)

**Image/Page Drag-and-Drop Logic:**

- Updated image drag logic to allow images to be dragged beyond page boundaries, facilitating moving images to adjacent pages. This includes expanding the allowed drag area and updating the history tracking to record page changes for images. (`lib/components/canvas/canvas_image.dart`, `lib/data/editor/editor_history.dart`) [[1]](diffhunk://#diff-f25703a96c0a0e2e489070580ea256a3bbf29a1a52a7d8794f35d0c5efc0458cR141-R143) [[2]](diffhunk://#diff-f25703a96c0a0e2e489070580ea256a3bbf29a1a52a7d8794f35d0c5efc0458cL146-R156) [[3]](diffhunk://#diff-d15d9ed5bed3bbc5bf738da489e16a42ed242fed181a748980fc16477371a6caR155) [[4]](diffhunk://#diff-d15d9ed5bed3bbc5bf738da489e16a42ed242fed181a748980fc16477371a6caR195-R198) [[5]](diffhunk://#diff-d15d9ed5bed3bbc5bf738da489e16a42ed242fed181a748980fc16477371a6caR209) [[6]](diffhunk://#diff-d15d9ed5bed3bbc5bf738da489e16a42ed242fed181a748980fc16477371a6caR222)

**Codebase Consistency and Documentation:**

- Added file-level documentation and `library;` directives to several Dart files for improved clarity and consistency. (`lib/components/canvas/canvas_gesture_detector.dart`, `lib/components/canvas/canvas_image.dart`, `lib/components/toolbar/editor_bottom_sheet.dart`, `lib/components/toolbar/toolbar.dart`, `lib/data/editor/editor_history.dart`, `lib/data/editor/page.dart`, `lib/pages/editor/editor.dart`) [[1]](diffhunk://#diff-ddea2cd1bcc2c61e0caf07917cfd0a29cc9846fbec6671a8e6574757e38eff78R1-R3) [[2]](diffhunk://#diff-f25703a96c0a0e2e489070580ea256a3bbf29a1a52a7d8794f35d0c5efc0458cR1-R3) [[3]](diffhunk://#diff-bb7bcb4c4de82a9fdde9853e32f59a85d15361d06038c83d5654fc01fadd1744R1-R3) [[4]](diffhunk://#diff-2cef952a2ccfc933faab8348136619d4023ad926af8248154c7f85bc22fc7ebbR1-R3) [[5]](diffhunk://#diff-d15d9ed5bed3bbc5bf738da489e16a42ed242fed181a748980fc16477371a6caR1-R3) [[6]](diffhunk://#diff-171cb90f81a9ad8b0f5155c2180b08483bb42bcd87a1d9f90617ef32156d7fedR1-R3) [[7]](diffhunk://#diff-9a194fe24f25ea5e2b2323ed2e42c784633358129095624f76e91829f4c174a2R1-R17)

**Canvas/Page Layout:**

- Centralized the vertical gap between pages into a single constant `EditorPage.gapBetweenPages` and updated all relevant calculations to use this value. (`lib/data/editor/page.dart`, `lib/components/canvas/canvas_gesture_detector.dart`, `lib/components/canvas/canvas_image.dart`) [[1]](diffhunk://#diff-171cb90f81a9ad8b0f5155c2180b08483bb42bcd87a1d9f90617ef32156d7fedR27-R29) [[2]](diffhunk://#diff-ddea2cd1bcc2c61e0caf07917cfd0a29cc9846fbec6671a8e6574757e38eff78L94-R97) [[3]](diffhunk://#diff-ddea2cd1bcc2c61e0caf07917cfd0a29cc9846fbec6671a8e6574757e38eff78L136-R139) [[4]](diffhunk://#diff-f25703a96c0a0e2e489070580ea256a3bbf29a1a52a7d8794f35d0c5efc0458cL146-R156)

These changes collectively improve iOS input support, make image insertion more flexible, and enhance the overall codebase maintainability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Apple Pencil double‑tap support on iOS to toggle the eraser and expands image insertion with a new “Insert from Files” option, plus lets images be dragged across pages with full undo/redo.
These changes improve iOS input, photo import workflow, and cross‑page editing.

- **New Features**
  - Apple Pencil double‑tap toggles eraser on iOS and respects the system “Off” setting.
  - New toolbar/bottom‑sheet option to insert images from Files on iOS; Photos remains the default. PDFs from Files are imported via the existing PDF flow. Uses `image_picker` (Photos) and `file_picker` (Files).
  - Images can be dragged past page edges to move to adjacent pages; history tracks page changes for undo/redo.

- **Improvements**
  - Inserted photos are non‑invertible by default to preserve original colors.
  - Current page detection now uses the viewport center so new inserts land on the viewed page.
  - Centralized page gap as `EditorPage.gapBetweenPages`; updated related gesture/drag clamps.
  - Added tests for Pencil double‑tap, photo insertion, and cross‑page image moves; added `file_selector_macos` dependency.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 6d4aba417b5dd08cbe48ea818d6dabd50e7801d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

