### PR TITLE
ci: cache apt install

### DIFF
--- a/.github/shared_workflows/cache_apt/action.yml
+++ b/.github/shared_workflows/cache_apt/action.yml
@@ -27,7 +27,7 @@ runs:
         sudo cp -a .aptcache/lists/* /var/lib/apt/lists/
 
     - name: Update apt repos
-      if: ${{ steps.cache-apt.outputs.cache-hit == '' }}
+      if: ${{ startsWith(github.ref, 'refs/tags/') || steps.cache-apt.outputs.cache-hit == '' }}
       shell: bash
       run: sudo apt-get update -yq
 

--- a/.github/shared_workflows/cache_apt/action.yml
+++ b/.github/shared_workflows/cache_apt/action.yml
@@ -1,0 +1,46 @@
+name: "Cache apt"
+description: "Installs and caches a list of apt packages"
+
+inputs:
+  packages:
+    description: The list of packages to install
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore cache
+      id: cache-apt-archives
+      uses: actions/cache/restore@v6
+      with:
+        path: |
+          .apt-archives-cache
+        key: apt-archives-cache-${{ inputs.packages }}
+
+    - name: Move cached files
+      if: ${{ steps.cache-apt-archives.outputs.cache-hit != '' }}
+      shell: bash
+      run: |
+        sudo mkdir -p /var/cache/apt/archives
+        sudo cp -l .apt-archives-cache/*.deb /var/cache/apt/archives/
+
+    - name: Update apt repos
+      if: ${{ steps.cache-apt-archives.outputs.cache-hit == '' }}
+      shell: bash
+      run: sudo apt-get update -yq
+
+    - name: Install packages
+      shell: bash
+      run: |
+        sudo apt-get install -yq ${{ inputs.packages }}
+
+        mkdir -p .apt-archives-cache
+        sudo cp -l /var/cache/apt/archives/*.deb .apt-archives-cache
+
+    - name: Save cache
+      uses: actions/cache/save@v6
+      if: ${{ steps.cache-apt-archives.outputs.cache-hit == '' }}
+      with:
+        path: |
+          .apt-archives-cache
+        key: ${{ steps.cache-apt-archives.outputs.cache-primary-key }}

--- a/.github/shared_workflows/cache_apt/action.yml
+++ b/.github/shared_workflows/cache_apt/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         path: |
           .aptcache
-        key: ${{ runner.OS }}-aptcache-${{ inputs.packages }}
+        key: ${{ runner.OS }}-${{ runner.arch }}-aptcache-${{ inputs.packages }}
 
     - name: Move files from cache
       if: ${{ steps.cache-apt.outputs.cache-hit != '' }}

--- a/.github/shared_workflows/cache_apt/action.yml
+++ b/.github/shared_workflows/cache_apt/action.yml
@@ -10,37 +10,43 @@ runs:
   using: composite
   steps:
     - name: Restore cache
-      id: cache-apt-archives
+      id: cache-apt
       uses: actions/cache/restore@v6
       with:
         path: |
-          .apt-archives-cache
-        key: apt-archives-cache-${{ inputs.packages }}
+          .aptcache
+        key: ${{ runner.OS }}-aptcache-${{ inputs.packages }}
 
-    - name: Move cached files
-      if: ${{ steps.cache-apt-archives.outputs.cache-hit != '' }}
+    - name: Move files from cache
+      if: ${{ steps.cache-apt.outputs.cache-hit != '' }}
       shell: bash
       run: |
-        sudo mkdir -p /var/cache/apt/archives
-        sudo cp -l .apt-archives-cache/*.deb /var/cache/apt/archives/
+        mkdir -p .aptcache/archives/ .aptcache/lists/
+        sudo mkdir -p /var/cache/apt/archives /var/lib/apt/lists
+        sudo cp -l .aptcache/archives/*.deb /var/cache/apt/archives/
+        sudo cp -lr .aptcache/lists/* /var/lib/apt/lists/
 
     - name: Update apt repos
-      if: ${{ steps.cache-apt-archives.outputs.cache-hit == '' }}
+      if: ${{ steps.cache-apt.outputs.cache-hit == '' }}
       shell: bash
       run: sudo apt-get update -yq
 
     - name: Install packages
       shell: bash
       run: |
-        sudo apt-get install -yq ${{ inputs.packages }}
+        sudo apt-get install -yqq ${{ inputs.packages }}
 
-        mkdir -p .apt-archives-cache
-        sudo cp -l /var/cache/apt/archives/*.deb .apt-archives-cache
+    - name: Move files for caching
+      shell: bash
+      run: |
+        mkdir -p .aptcache/archives/ .aptcache/lists/
+        sudo cp -l /var/cache/apt/archives/*.deb .aptcache/archives/
+        sudo cp -lr /var/lib/apt/lists/* .aptcache/lists/
 
     - name: Save cache
       uses: actions/cache/save@v6
-      if: ${{ steps.cache-apt-archives.outputs.cache-hit == '' }}
+      if: ${{ steps.cache-apt.outputs.cache-hit == '' }}
       with:
         path: |
-          .apt-archives-cache
-        key: ${{ steps.cache-apt-archives.outputs.cache-primary-key }}
+          .aptcache
+        key: ${{ steps.cache-apt.outputs.cache-primary-key }}

--- a/.github/shared_workflows/cache_apt/action.yml
+++ b/.github/shared_workflows/cache_apt/action.yml
@@ -24,7 +24,7 @@ runs:
         mkdir -p .aptcache/archives/ .aptcache/lists/
         sudo mkdir -p /var/cache/apt/archives /var/lib/apt/lists
         sudo cp -l .aptcache/archives/*.deb /var/cache/apt/archives/
-        sudo cp -lr .aptcache/lists/* /var/lib/apt/lists/
+        sudo cp -a .aptcache/lists/* /var/lib/apt/lists/
 
     - name: Update apt repos
       if: ${{ steps.cache-apt.outputs.cache-hit == '' }}
@@ -33,15 +33,16 @@ runs:
 
     - name: Install packages
       shell: bash
-      run: |
-        sudo apt-get install -yqq ${{ inputs.packages }}
+      run: sudo apt-get install -yqq ${{ inputs.packages }}
 
     - name: Move files for caching
+      if: ${{ steps.cache-apt.outputs.cache-hit == '' }}
       shell: bash
       run: |
         mkdir -p .aptcache/archives/ .aptcache/lists/
         sudo cp -l /var/cache/apt/archives/*.deb .aptcache/archives/
-        sudo cp -lr /var/lib/apt/lists/* .aptcache/lists/
+        sudo find /var/lib/apt/lists -maxdepth 1 -type f -exec cp -a -t .aptcache/lists/ {} +
+        sudo chmod -R a+r .aptcache
 
     - name: Save cache
       uses: actions/cache/save@v6

--- a/.github/shared_workflows/install_apt_dependencies/action.yml
+++ b/.github/shared_workflows/install_apt_dependencies/action.yml
@@ -5,7 +5,6 @@ runs:
   using: "composite"
   steps:
     - name: Install apt dependencies
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libgtk-3-dev libx11-dev pkg-config cmake ninja-build curl libcurl4-openssl-dev libblkid-dev libsecret-1-dev libjsoncpp-dev ghostscript libunwind-dev webkit2gtk-4.1-dev
+      uses: "./.github/shared_workflows/cache_apt"
+      with:
+        packages: libgtk-3-dev libx11-dev pkg-config cmake ninja-build curl libcurl4-openssl-dev libblkid-dev libsecret-1-dev libjsoncpp-dev ghostscript libunwind-dev webkit2gtk-4.1-dev


### PR DESCRIPTION
Before this PR:
- All runs take ~64s to apt install

After this PR:
- Cold runs take 28s
- Warm runs take 20s

---

- [X] I have read [CONTRIBUTING.md]. I have followed the requirements including but not limited to the licensing requirements.
- [X] I understand my contribution in full and will be able to respond to review comments.
- [X] I have tested my contribution and it works as described.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches apt packages and lists in CI to speed installs. Previously every run updated and installed apt packages (~64s); now we reuse cached archives and lists (cold ~28s, warm ~20s) and only run apt-get update on cache miss or tagged builds.

- Adds composite action `./.github/shared_workflows/cache_apt` using `actions/cache/restore@v6` and `actions/cache/save@v6`; cache key `${{ runner.OS }}-${{ runner.arch }}-aptcache-${{ inputs.packages }}` isolates caches by OS, arch, and package set.
- On cache hit it restores to `/var/cache/apt/archives` and `/var/lib/apt/lists` and runs `apt-get install -yqq`; on miss or tags it runs `apt-get update`, installs, and saves the cache.
- `./.github/shared_workflows/install_apt_dependencies` now calls this action with the existing package set. Side effect: on branch builds with cache hits, package indexes are not refreshed.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit dd76c8a099ec921f8bf9b88c482d44e88c506065. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



