### PR TITLE
i18n: Update Czech

### DIFF
--- a/lib/i18n/_missing_translations.yaml
+++ b/lib/i18n/_missing_translations.yaml
@@ -232,8 +232,6 @@ ca:
       lockSingleFingerPan(OUTDATED): Disable single-finger panning
       unlockAxisAlignedPan(OUTDATED): Unlock panning to horizontal or vertical
 cs:
-  profile:
-    quotaUsageUncapped(OUTDATED): Využíváte $used
 de:
   home:
     sort:

--- a/lib/i18n/_missing_translations.yaml
+++ b/lib/i18n/_missing_translations.yaml
@@ -233,7 +233,7 @@ ca:
       unlockAxisAlignedPan(OUTDATED): Unlock panning to horizontal or vertical
 cs:
   profile:
-    quotaUsageUncapped(OUTDATED): You're using $used
+    quotaUsageUncapped(OUTDATED): Využíváte $used
 de:
   home:
     sort:

--- a/lib/i18n/cs.i18n.yaml
+++ b/lib/i18n/cs.i18n.yaml
@@ -231,6 +231,7 @@ profile:
   title: Můj profil
   logout: Odhlásit se
   quotaUsage: Využíváte $used z $total ($percent %)
+  quotaUsageUncapped: Využíváte $used
   connectedTo: Připojeno k
   quickLinks:
     serverHomepage: Webové stránky serveru
@@ -253,7 +254,6 @@ profile:
       Klepněte na tlačítko „@:profile.quickLinks.deleteAccount“ umístěné výše a přihlašte se, pokud to bude vyžadováno.
       Pokud používáte oficiální server od aplikace Saber, bude váš účet odstraněn po uplynutí týdenní ochranné lhůty. Během této lhůty mě můžete kontaktovat pro odvolání zrušení účtu na adilhanney@disroot.org.
       Pokud používáte server třetí strany, nemusí nabízet možnost odstranění účtu: pro více informací se bude třeba obrátit na zásady ochrany osobních údajů daného serveru.
-  quotaUsageUncapped(OUTDATED): Používáte $used
 appInfo:
   licenseNotice: |-
     Saber  Copyright © 2022-$buildYear  Adil Hanney

--- a/lib/i18n/strings_cs.g.dart
+++ b/lib/i18n/strings_cs.g.dart
@@ -171,6 +171,7 @@ class _Translations$profile$cs extends Translations$profile$en {
 	@override String get title => 'Můj profil';
 	@override String get logout => 'Odhlásit se';
 	@override String quotaUsage({required Object used, required Object total, required Object percent}) => 'Využíváte ${used} z ${total} (${percent} %)';
+	@override String quotaUsageUncapped({required Object used}) => 'Využíváte ${used}';
 	@override String get connectedTo => 'Připojeno k';
 	@override late final _Translations$profile$quickLinks$cs quickLinks = _Translations$profile$quickLinks$cs._(_root);
 	@override String get faqTitle => 'Často kladené otázky';
@@ -180,7 +181,6 @@ class _Translations$profile$cs extends Translations$profile$en {
 		_Translations$profile$faq$2$cs._(_root),
 		_Translations$profile$faq$3$cs._(_root),
 	];
-	@override String quotaUsageUncapped({required Object used}) => 'Používáte ${used}';
 }
 
 // Path: appInfo


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/saber-notes/saber/blob/main/.github/CONTRIBUTING.md). I have followed the requirements including but not limited to the licensing requirements.
- [x] I understand my contribution in full and will be able to respond to review comments.
- [ ] I have tested my contribution and it works as described.

Hello @adil192! As Weblate doesn't seem to work for Saber, I'm sending the Czech translation for the new string via a pull request, so we have a 100% Czech translation again. I didn't test it to be honest, but I think it should be okay (the Czech version is even shorter than the English one…).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the Czech translation for the unlimited quota usage message so the app is fully translated into Czech again.

- Adds `quotaUsageUncapped` to `lib/i18n/cs.i18n.yaml` and `strings_cs.g.dart` as "Využíváte $used".
- Removes the old translation from `lib/i18n/_missing_translations.yaml` and drops the outdated placeholder.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 4d20e2e207ed3b0733ff44a1dfd26e1ce6b5ba02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



