### PR TITLE
Fix multi-touch gesture handling on window blur

### DIFF
--- a/lib/components/canvas/canvas_gesture_detector.dart
+++ b/lib/components/canvas/canvas_gesture_detector.dart
@@ -15,6 +15,7 @@ import 'package:saber/data/extensions/matrix4_extensions.dart';
 import 'package:saber/data/prefs.dart';
 import 'package:saber/pages/editor/editor.dart';
 import 'package:vector_math/vector_math_64.dart';
+import 'package:window_manager/window_manager.dart';
 
 class CanvasGestureDetector extends StatefulWidget {
   new({
@@ -143,8 +144,17 @@ class CanvasGestureDetector extends StatefulWidget {
   }
 }
 
-class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
+class CanvasGestureDetectorState extends State<CanvasGestureDetector>
+    with WindowListener, WidgetsBindingObserver {
   late var containerBounds = const BoxConstraints();
+  final Set<int> _activePointers = {};
+
+  void _cancelAllActivePointers() {
+    for (final pointer in _activePointers.toList()) {
+      GestureBinding.instance.cancelPointer(pointer);
+    }
+    _activePointers.clear();
+  }
 
   /// If zooming is locked, this is the zoom level.
   /// Otherwise, this is null.
@@ -314,7 +324,23 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
     setInitialTransform();
     widget._transformationController.addListener(onTransformChanged);
     _assignKeybindings();
+    if (Stows.isDesktop) {
+      windowManager.addListener(this);
+      WidgetsBinding.instance.addObserver(this);
+    }
     super.initState();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) {
+      _cancelAllActivePointers();
+    }
+  }
+
+  @override
+  void onWindowBlur() {
+    _cancelAllActivePointers();
   }
 
   /// When the widget is created, we still have an empty coreInfo.
@@ -419,6 +445,9 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
   }
 
   void _listenerPointerEvent(PointerEvent event) {
+    if (event is PointerDownEvent) {
+      _activePointers.add(event.pointer);
+    }
     final isStylus =
         event.kind == PointerDeviceKind.stylus ||
         event.kind == PointerDeviceKind.invertedStylus;
@@ -477,6 +506,7 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
   }
 
   void _listenerPointerUpEvent(PointerEvent event) {
+    _activePointers.remove(event.pointer);
     widget.updatePointerData(event.kind, null);
     if (stylusButtonWasPressed) {
       stylusButtonWasPressed = false;
@@ -494,6 +524,7 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
           onPointerDown: _listenerPointerEvent,
           onPointerMove: _listenerPointerEvent,
           onPointerUp: _listenerPointerUpEvent,
+          onPointerCancel: _listenerPointerUpEvent,
           onPointerHover: _listenerPointerHoverEvent,
           child: GestureDetector(
             child: LayoutBuilder(
@@ -567,6 +598,11 @@ class CanvasGestureDetectorState extends State<CanvasGestureDetector> {
 
   @override
   void dispose() {
+    if (Stows.isDesktop) {
+      windowManager.removeListener(this);
+      WidgetsBinding.instance.removeObserver(this);
+      _cancelAllActivePointers();
+    }
     CanvasTransformCache.add(
       widget.filePath,
       widget._transformationController.value,

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -520,7 +520,10 @@ class EditorState extends State<Editor> {
         .notifyListenersPlease(); // un-select active image
 
     _lastSeenPointerCountTimer?.cancel();
-    if (lastSeenPointerCount >= 2) {
+    if (details.pointerCount == 1 && lastSeenPointerCount >= 2) {
+      // Previous gesture was interrupted or left incomplete, reset pointer count
+      lastSeenPointerCount = 1;
+    } else if (lastSeenPointerCount >= 2) {
       // was a zoom gesture, ignore
       lastSeenPointerCount = lastSeenPointerCount;
       return false;

--- a/test/interrupted_gesture_recovery_test.dart
+++ b/test/interrupted_gesture_recovery_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/data/flavor_config.dart';
+import 'package:saber/data/prefs.dart';
+import 'package:saber/pages/editor/editor.dart';
+
+import 'utils/test_mock_channel_handlers.dart';
+
+void main() {
+  group('Interrupted Gesture Recovery', () {
+    FlavorConfig.setup();
+    FileManager.documentsDirectory =
+        '$tmpDir/gesture_test/'
+        '${FileManager.appRootDirectoryPrefix}';
+    stows.editorFingerDrawing.value = false;
+
+    testWidgets(
+      'Should recover and draw stroke after interrupted multi-pointer gesture',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(home: Editor(path: '/gesture-recovery-test')),
+        );
+        final editorState = tester.state<EditorState>(find.byType(Editor));
+        await tester.pump();
+        final page = editorState.coreInfo.pages.first;
+        expect(page.strokes, isEmpty);
+
+        // Simulate an interrupted 3-finger touchpad swipe leaving pointer count >= 2
+        editorState.lastSeenPointerCount = 3;
+
+        // Perform a single-pointer stylus stroke
+        final center = tester.getCenter(find.byType(Editor));
+        final gesture =
+            await tester.createGesture(kind: PointerDeviceKind.stylus);
+        await gesture.down(center);
+        for (var i = 0; i < 5; ++i) {
+          await gesture.moveBy(
+            Offset(i.toDouble(), i.toDouble()),
+            timeStamp: Duration(milliseconds: i * 50),
+          );
+        }
+        await gesture.up(timeStamp: const Duration(milliseconds: 300));
+        await tester.pump();
+
+        // Stroke should be successfully recorded instead of rejected
+        expect(page.strokes, hasLength(1));
+      },
+    );
+  });
+}


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/saber-notes/saber/blob/main/.github/CONTRIBUTING.md). I have followed the requirements including but not limited to the licensing requirements.
- [X] I understand my contribution in full and will be able to respond to review comments.
- [x] I have tested my contribution and it works as described.

    ### What this PR fixes

    Fixes #1820 

    On touchscreen devices running Linux (GNOME), doing a 3-finger swipe on the screen to switch workspaces leaves touch pointers stuck in the gesture recognizer. While stylus drawing still works, moving the canvas with one finger afterwards zooms instead of moving until the note is closed and reopened.

    ### Changes

    - **Pointer cancellation on window blur**: Tracks active pointers and cancels them via `GestureBinding.instance.cancelPointer` when the window loses focus or the gesture is intercepted.
    - **Pointer count recovery**: Resets `lastSeenPointerCount` back to `1` in `isDrawGesture` when a new single-pointer gesture starts.
    - **Pointer cancel event handling**: Added `onPointerCancel` listener.
    - **Automated test**: Added `test/interrupted_gesture_recovery_test.dart`.

    ### Testing

    - Ran `flutter test test/interrupted_gesture_recovery_test.dart` (passed).
    - Ran `flutter test test/stylus_test.dart` (passed).
    - Ran `flutter analyze` (no issues found).
    - Manually tested 3-finger touchscreen gestures on Linux (GNOME).

**Note on AI assistance**: This PR was developed with some AI assistance (creating the automated test).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1820: on Linux (GNOME) touchscreens, a 3-finger swipe to switch workspaces left touch pointers stuck in the gesture recognizer, so single-finger canvas drags zoomed instead of panning until the note was reopened. Active pointers are now cancelled when the window loses focus or the app is backgrounded, and the gesture pointer count resets when a new single-pointer gesture starts.

**Bug Fixes**
- Cancels active pointers via `GestureBinding.instance.cancelPointer` when the window blurs, the app is backgrounded, or a pointer is cancelled.
- Resets `lastSeenPointerCount` when a new single-pointer gesture starts after an interrupted multi-touch gesture.
- Adds an automated test covering recovery after an interrupted multi-pointer gesture.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit b35e1f50b2266c3363ecdde7af8d1436a3f2ec23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

