### PR TITLE
fix: appimage zsync url

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,11 +123,10 @@ jobs:
           mv linux/AppImage/AppDir/usr/bin/share linux/AppImage/AppDir/usr/
 
           # Set environment variables for linuxdeploy
-          echo "LD_LIBRARY_PATH=$(pwd)/linux/AppImage/AppDir/usr/bin/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo 'UPDATE_INFORMATION=gh-releases-zsync|saber-notes|saber|latest|Saber-*-${{ matrix.arch.archive-suffix }}.AppImage.zsync' >> $GITHUB_ENV
-
           buildName=$(grep -oP "(?<=buildName = ').*(?=')" lib/data/version.dart)
-          echo "LINUXDEPLOY_OUTPUT_APP_NAME=Saber-${buildName}" >> $GITHUB_ENV
+          echo "LDAI_OUTPUT=Saber-${buildName}-${{ matrix.arch.archive-suffix }}.AppImage" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$(pwd)/linux/AppImage/AppDir/usr/bin/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo 'LDAI_UPDATE_INFORMATION=gh-releases-zsync|saber-notes|saber|latest|Saber-*-${{ matrix.arch.archive-suffix }}.AppImage.zsync' >> $GITHUB_ENV
 
       - name: Install linuxdeploy
         working-directory: linux/AppImage

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,6 @@ on:
       - "**"
     paths:
       - .github/workflows/linux.yml
-      - appimage/AppImageBuilder.yml
 
 jobs:
   build-linux:
@@ -120,12 +119,15 @@ jobs:
           mkdir -p linux/AppImage/AppDir/usr/bin/
           cp -R AppDir/* linux/AppImage/AppDir/usr/bin/
 
-          # Move share folder to usr/share
+          # Move /usr/bin/share to /usr/share
           mv linux/AppImage/AppDir/usr/bin/share linux/AppImage/AppDir/usr/
 
           # Set environment variables for linuxdeploy
           echo "LD_LIBRARY_PATH=$(pwd)/linux/AppImage/AppDir/usr/bin/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo 'UPDATE_INFORMATION=gh-releases-zsync|saber-notes|saber|latest|Saber-*-${{ matrix.arch.archive-suffix }}.AppImage.zsync' >> $GITHUB_ENV
+
+          buildName=$(grep -oP "(?<=buildName = ').*(?=')" lib/data/version.dart)
+          echo "LINUXDEPLOY_OUTPUT_APP_NAME=Saber-${buildName}" >> $GITHUB_ENV
 
       - name: Install linuxdeploy
         working-directory: linux/AppImage
@@ -137,12 +139,6 @@ jobs:
         run: ./${{ matrix.arch.linuxdeploy-exe }} --appdir AppDir --output appimage
 
       - run: tree linux/AppImage -L 3
-
-      - name: Rename AppImage
-        run: |
-          buildName=$(grep -oP "(?<=buildName = ').*(?=')" lib/data/version.dart)
-          mv linux/AppImage/Saber-*.AppImage       linux/AppImage/Saber-${buildName}-${{ matrix.arch.archive-suffix }}.AppImage
-          mv linux/AppImage/Saber-*.AppImage.zsync linux/AppImage/Saber-${buildName}-${{ matrix.arch.archive-suffix }}.AppImage.zsync
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ app.*.map.json
 .flatpak-builder
 build-dir
 Saber-Linux-Portable.tar.gz
+AppDir/
+*.AppImage*
 
 # Sentry error tracking
 .sentry-native/

--- a/linux/AppImage/.gitignore
+++ b/linux/AppImage/.gitignore
@@ -1,2 +1,0 @@
-AppDir
-*.AppImage*


### PR DESCRIPTION
This should fix #1812 (context: https://github.com/kem-a/AppManager/issues/174).

Before and after with a local build:
```console
ahann@dellpro:~/Documents/GitHub/saber/linux/AppImage$ head -n 8 Saber-x86_64.AppImage.zsync 
zsync: 0.6.2
Filename: Saber-x86_64.AppImage
MTime: Thu, 03 Sep 2026 23:52:42 +0000
Blocksize: 4096
Length: 130755064
Hash-Lengths: 2,2,5
URL: Saber-x86_64.AppImage
SHA-1: db9239f7bb5ed5e00439f34d0c453ffb844ad2ac
ahann@dellpro:~/Documents/GitHub/saber/linux/AppImage$ head -n 8 Saber-*-x86_64.AppImage.zsync 
zsync: 0.6.2
Filename: Saber-1.36.1-x86_64.AppImage
MTime: Thu, 03 Sep 2026 23:57:43 +0000
Blocksize: 4096
Length: 130755064
Hash-Lengths: 2,2,5
URL: Saber-1.36.1-x86_64.AppImage
SHA-1: a99ea853dfe57b0b73d80bb70dc9dcf93192c8f7
ahann@dellpro:~/Documents/GitHub/saber/linux/AppImage$ 
```

- [X] I have read [CONTRIBUTING.md](https://github.com/saber-notes/saber/blob/main/.github/CONTRIBUTING.md). I have followed the requirements including but not limited to the licensing requirements.
- [X] I understand my contribution in full and will be able to respond to review comments.
- [X] I have tested my contribution and it works as described.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AppImage zsync URL so delta updates work again in AppImage managers. The previous build renamed the AppImage after linuxdeploy generated the zsync file, leaving the zsync URL pointing to a filename that didn't exist. Now linuxdeploy names the AppImage with the version up front via `LDAI_OUTPUT` (needed because we use the non-standard `arm64` suffix), and the `.gitignore` rules for AppImage build artifacts are consolidated into the root `.gitignore`.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit f626b93c72807d6b13a6a0cfbba0e92711c7121c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

