### PR TITLE
fix: Prevent adding .pdf files as image

### DIFF
--- a/lib/i18n/de.i18n.yaml
+++ b/lib/i18n/de.i18n.yaml
@@ -355,6 +355,9 @@ editor:
       staffs: Notenpapier
       tablature: Tablature
       cornell: Cornell-Stil
+  photoPdfError:
+    title: Fehler
+    message: PDF-Dateien können nicht als Bild hinzugefügt werden. Nutze dafür "Import > PDF".
   readOnlyBanner:
     title: Schreibgeschützter Modus
     watchingServer: Sie warten derzeit auf Aktualisierungen des Servers. Die Bearbeitung ist in diesem Modus deaktiviert.

--- a/lib/i18n/en.i18n.yaml
+++ b/lib/i18n/en.i18n.yaml
@@ -355,6 +355,9 @@ editor:
       staffs: Staffs
       tablature: Tablature
       cornell: Cornell
+  photoPdfError:
+    title: Error
+    message: PDF files cannot be added as image. Use "Import > PDF" for that.
   readOnlyBanner:
     title: Read-only mode
     watchingServer: You are currently watching for updates on the server. Editing is disabled in this mode.

--- a/lib/i18n/strings_de.g.dart
+++ b/lib/i18n/strings_de.g.dart
@@ -224,6 +224,7 @@ class _Translations$editor$de extends Translations$editor$en {
 	@override late final _Translations$editor$imageOptions$de imageOptions = _Translations$editor$imageOptions$de._(_root);
 	@override late final _Translations$editor$selectionBar$de selectionBar = _Translations$editor$selectionBar$de._(_root);
 	@override late final _Translations$editor$menu$de menu = _Translations$editor$menu$de._(_root);
+	@override late final _Translations$editor$photoPdfError$de photoPdfError = _Translations$editor$photoPdfError$de._(_root);
 	@override late final _Translations$editor$readOnlyBanner$de readOnlyBanner = _Translations$editor$readOnlyBanner$de._(_root);
 	@override late final _Translations$editor$versionTooNew$de versionTooNew = _Translations$editor$versionTooNew$de._(_root);
 	@override late final _Translations$editor$quill$de quill = _Translations$editor$quill$de._(_root);
@@ -792,6 +793,17 @@ class _Translations$editor$menu$de extends Translations$editor$menu$en {
 	@override String get watchServerReadOnly => 'Bearbeiten ist deaktiviert, solange du den Server beobachtest';
 	@override late final _Translations$editor$menu$boxFits$de boxFits = _Translations$editor$menu$boxFits$de._(_root);
 	@override late final _Translations$editor$menu$bgPatterns$de bgPatterns = _Translations$editor$menu$bgPatterns$de._(_root);
+}
+
+// Path: editor.photoPdfError
+class _Translations$editor$photoPdfError$de extends Translations$editor$photoPdfError$en {
+	_Translations$editor$photoPdfError$de._(TranslationsDe root) : this._root = root, super.internal(root);
+
+	final TranslationsDe _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Fehler';
+	@override String get message => 'PDF-Dateien können nicht als Bild hinzugefügt wreden. Nutze dafür "Import > PDF".';
 }
 
 // Path: editor.readOnlyBanner

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -310,6 +310,7 @@ class Translations$editor$en {
 	late final Translations$editor$imageOptions$en imageOptions = Translations$editor$imageOptions$en.internal(_root);
 	late final Translations$editor$selectionBar$en selectionBar = Translations$editor$selectionBar$en.internal(_root);
 	late final Translations$editor$menu$en menu = Translations$editor$menu$en.internal(_root);
+	late final Translations$editor$photoPdfError$en photoPdfError = Translations$editor$photoPdfError$en.internal(_root);
 	late final Translations$editor$readOnlyBanner$en readOnlyBanner = Translations$editor$readOnlyBanner$en.internal(_root);
 	late final Translations$editor$versionTooNew$en versionTooNew = Translations$editor$versionTooNew$en.internal(_root);
 	late final Translations$editor$quill$en quill = Translations$editor$quill$en.internal(_root);
@@ -1308,6 +1309,21 @@ class Translations$editor$menu$en {
 
 	late final Translations$editor$menu$boxFits$en boxFits = Translations$editor$menu$boxFits$en.internal(_root);
 	late final Translations$editor$menu$bgPatterns$en bgPatterns = Translations$editor$menu$bgPatterns$en.internal(_root);
+}
+
+// Path: editor.photoPdfError
+class Translations$editor$photoPdfError$en {
+	Translations$editor$photoPdfError$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Error'
+	String get title => 'Error';
+
+	/// en: 'PDF files cannot be added as image. Use "Import > PDF" for that.'
+	String get message => 'PDF files cannot be added as image. Use "Import > PDF" for that.';
 }
 
 // Path: editor.readOnlyBanner

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -1097,9 +1097,26 @@ class EditorState extends State<Editor> {
     // use the Select tool so that the user can move the new image
     currentTool = Select.currentSelect;
 
-    final images = [
-      for (final _PhotoInfo photoInfo in photoInfos)
-        if (photoInfo.extension == '.svg')
+    var images = <EditorImage>[];
+    for (final _PhotoInfo photoInfo in photoInfos) {
+      if (photoInfo.extension == '.pdf') {
+        //Android allows pdf selection even if not allowed
+        showDialog(
+          context: context,
+          builder: (context) => AdaptiveAlertDialog(
+            title: Text(t.editor.photoPdfError.title),
+            content: Text(t.editor.photoPdfError.message),
+            actions: [
+              CupertinoDialogAction(
+                child: Text(t.common.done),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            ],
+          ),
+        );
+        continue;
+      } else if (photoInfo.extension == '.svg') {
+        images.add(
           SvgEditorImage(
             id: coreInfo.nextImageId++,
             svgString: utf8.decode(photoInfo.bytes),
@@ -1112,7 +1129,9 @@ class EditorState extends State<Editor> {
             onLoad: () => setState(() {}),
             assetCache: coreInfo.assetCache,
           )
-        else
+        );
+      } else {
+        images.add(
           PngEditorImage(
             id: coreInfo.nextImageId++,
             extension: photoInfo.extension,
@@ -1124,8 +1143,14 @@ class EditorState extends State<Editor> {
             onMiscChange: autosaveAfterDelay,
             onLoad: () => setState(() {}),
             assetCache: coreInfo.assetCache,
-          ),
-    ];
+          )
+        );
+      }
+    }
+
+    if (images.isEmpty) {
+      return 0;
+    }
 
     history.recordChange(
       EditorHistoryItem(


### PR DESCRIPTION
At least on Android, the image file picker allows to select pdf files. This leads to corrupted note files that cannot be opened anymore, leading to the following error:

```
Failed to load file: type 'Null' is not a subtype of type 'int'
#0      new PdfEditorImage.fromJson (package:saber/components/canvas/image/pdf_editor_image.dart:82)
#1      new EditorImage.fromJson (package:saber/components/canvas/image/editor_image.dart:131)
#2      EditorPage.parseImageJson (package:saber/data/editor/page.dart:268)
#3      EditorPage.parseImagesJson.<anonymous closure> (package:saber/data/editor/page.dart:249)
```

Related: https://github.com/saber-notes/saber/issues/1689, https://github.com/saber-notes/saber/issues/1159

- [x] I have read [CONTRIBUTING.md](https://github.com/saber-notes/saber/blob/main/.github/CONTRIBUTING.md). I have followed the requirements including but not limited to the licensing requirements.
- [x] I understand my contribution in full and will be able to respond to review comments.
- [x] I have tested my contribution and it works as described.

Notes:
- This can be tested on Linux by adding `pdf` to `allowedExtensions` in `lib/pages/editor/editor.dart`.
- I have no idea how to fill `_missing_translations.yaml` automatically from the english ones
- I have no idea how to write a test for that case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android image picker allowing PDF selection, which corrupted notes. Now PDFs are rejected with an error dialog, and English/German translations are added.

- Detects `.pdf` extension before creating an image and shows a dialog instead.
- Adds `photoPdfError` translation keys for English and German.

Note: Saber is trialing Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful and are sure it's correct; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit d847c8e1261ac42bc7e2dd5559cbab21cac0555e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

